### PR TITLE
Fix issues in Docker Compose configurations

### DIFF
--- a/docker/logging/docker-compose.yml
+++ b/docker/logging/docker-compose.yml
@@ -32,7 +32,7 @@ services:
         soft: -1
         hard: -1
     volumes:
-      - /datapool/config/elasticsearch-config:/usr/share/elasticsearch/data
+      - /datapool/config/elasticsearch-config:/usr/share/elasticsearch/config
     ports:
       - "9200:9200"
     networks:

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -224,7 +224,7 @@ services:
       - /datapool/config/youtube-dl-config:/config
       - /datapool/media/youtube:/downloads
     ports:
-      - "8998:8080"
+      - "8998:8998"
     networks:
       - media-net
     restart: unless-stopped

--- a/docker/proxy/docker-compose.yml
+++ b/docker/proxy/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - "53:53/tcp"
       - "53:53/udp"
       - "3000:3000/tcp"  # Web arayüzü
-      - "80:80/tcp"      # HTTP redirect
+      - "8080:8080/tcp"  # HTTP redirect
     volumes:
       - /datapool/config/adguard-config/work:/opt/adguardhome/work
       - /datapool/config/adguard-config/conf:/opt/adguardhome/conf


### PR DESCRIPTION
Update docker-compose files to address potential issues.

* **docker/logging/docker-compose.yml**
  - Update the `elasticsearch` service to mount the configuration directory to `/usr/share/elasticsearch/config` instead of `/usr/share/elasticsearch/data`.

* **docker/media/docker-compose.yml**
  - Update the `youtube-dl` service to map port `8998` to `8998` instead of `8080`.

* **docker/proxy/docker-compose.yml**
  - Update the `adguard` service to map port `8080` for HTTP redirect instead of `80`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yakrel/proxmox-homelab-automation/pull/12?shareId=23696f81-3679-486d-b2f6-83edbe861adf).