### PR TITLE
Fix LXC IDs in README and scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,20 @@ Bu projeyle aşağıdaki hizmetleri kurabilirsiniz:
 - Proxmox VE 7.0 veya üzeri
 - ZFS depolama alanı (datapool)
 - Aşağıdaki LXC konteynerleri:
-  - **Media** (ID: 102): Sonarr, Radarr, Jellyfin vb. için
-  - **Monitoring** (ID: 103): Prometheus ve Grafana için  
-  - **Logging** (ID: 104): ELK Stack için
-  - **Proxy** (ID: 125): Cloudflared ve AdGuard Home için
+  - **Proxy** (ID: 100): Cloudflared ve AdGuard Home için
+  - **Media** (ID: 101): Sonarr, Radarr, Jellyfin vb. için
+  - **Monitoring** (ID: 102): Prometheus ve Grafana için  
+  - **Logging** (ID: 103): ELK Stack için
 
 > **Not**: Tüm konteynerlerde Docker kurulu olmalıdır.
 
 ## LXC Konteynerleri İçerikleri
 
-### Media Server (ID: 102)
+### Proxy (ID: 100)
+- Cloudflared - Cloudflare Tunnel
+- AdGuard Home - DNS filtreleme
+
+### Media Server (ID: 101)
 - Sonarr, Radarr - TV şovları ve film takibi
 - Bazarr - Altyazı yönetimi
 - Jellyfin - Medya sunucusu
@@ -43,21 +47,18 @@ Bu projeyle aşağıdaki hizmetleri kurabilirsiniz:
 - qBittorrent, Prowlarr, Flaresolverr, Recyclarr
 - Youtube-dl - YouTube video indirme
 
-### Monitoring (ID: 103)
+### Monitoring (ID: 102)
 - Prometheus - Metrik toplama
 - Grafana - Metrik görselleştirme
 - Alertmanager - Alarm yönetimi
 - Node Exporter - Host metrikleri
 
-### Logging (ID: 104)
+### Logging (ID: 103)
 - Elasticsearch - Log depolama
 - Logstash - Log işleme
 - Kibana - Log görselleştirme 
 - Filebeat - Log toplama
 
-### Proxy (ID: 125)
-- Cloudflared - Cloudflare Tunnel
-- AdGuard Home - DNS filtreleme
 
 ## Lisans
 

--- a/docker/logging/docker-compose.yml
+++ b/docker/logging/docker-compose.yml
@@ -1,4 +1,4 @@
-# LOGGING STACK INSTALLATION (LXC ID: 104)
+# LOGGING STACK INSTALLATION (LXC ID: 103)
 #
 # === STEP 1: PROXMOX HOST COMMANDS ===
 # Run these commands on the Proxmox host system:
@@ -10,7 +10,7 @@
 #    chown -R 100000:100000 /datapool
 #    
 #    # Mount datapool to LXC
-#    pct set 104 -mp0 /datapool,mp=/datapool
+#    pct set 103 -mp0 /datapool,mp=/datapool
 
 networks:
   logging-net:

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -1,4 +1,4 @@
-# MEDIA STACK INSTALLATION (LXC ID: 102)
+# MEDIA STACK INSTALLATION (LXC ID: 101)
 #
 # === STEP 1: PROXMOX HOST COMMANDS ===
 # Run these commands on the Proxmox host system:
@@ -12,7 +12,7 @@
 #    chown -R 100000:100000 /datapool
 #    
 #    # Mount datapool to LXC
-#    pct set 102 -mp0 /datapool,mp=/datapool
+#    pct set 101 -mp0 /datapool,mp=/datapool
 
 networks:
   media-net:

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -1,4 +1,4 @@
-# MONITORING STACK INSTALLATION (LXC ID: 103)
+# MONITORING STACK INSTALLATION (LXC ID: 102)
 #
 # === STEP 1: PROXMOX HOST COMMANDS ===
 # Run these commands on the Proxmox host system:
@@ -10,7 +10,7 @@
 #    chown -R 100000:100000 /datapool
 #    
 #    # Mount datapool to LXC
-#    pct set 103 -mp0 /datapool,mp=/datapool
+#    pct set 102 -mp0 /datapool,mp=/datapool
 
 networks:
   monitoring-net:

--- a/docker/proxy/docker-compose.yml
+++ b/docker/proxy/docker-compose.yml
@@ -1,4 +1,4 @@
-# PROXY STACK INSTALLATION (LXC ID: 125)
+# PROXY STACK INSTALLATION (LXC ID: 100)
 #
 # === STEP 1: PROXMOX HOST COMMANDS ===
 # Run these commands on the Proxmox host system:
@@ -10,7 +10,7 @@
 #    chown -R 100000:100000 /datapool
 #    
 #    # Mount datapool to LXC
-#    pct set 125 -mp0 /datapool,mp=/datapool
+#    pct set 100 -mp0 /datapool,mp=/datapool
 
 networks:
   proxy-net:

--- a/setup.sh
+++ b/setup.sh
@@ -48,8 +48,8 @@ fi
 echo "LXC konteynerlerine kurulum yapılıyor..."
 
 # LXC ID'leri
-LXC_IDS=("102" "103" "104" "125")
-LXC_NAMES=("media" "monitoring" "logging" "proxy")
+LXC_IDS=("100" "101" "102" "103")
+LXC_NAMES=("proxy" "media" "monitoring" "logging")
 
 # LXC'leri kontrol et ve işlemleri yap
 for i in "${!LXC_IDS[@]}"; do


### PR DESCRIPTION
Update LXC IDs in README, docker-compose files, and setup script to ensure consistency.

* **README.md**
  - Update LXC IDs to 100 for proxy, 101 for media, 102 for monitoring, and 103 for logging.
  - Adjust section titles and descriptions to reflect new LXC IDs.

* **docker/logging/docker-compose.yml**
  - Change LXC ID from 104 to 103 in comments and `pct set` command.

* **docker/media/docker-compose.yml**
  - Change LXC ID from 102 to 101 in comments and `pct set` command.

* **docker/monitoring/docker-compose.yml**
  - Change LXC ID from 103 to 102 in comments and `pct set` command.

* **docker/proxy/docker-compose.yml**
  - Change LXC ID from 125 to 100 in comments and `pct set` command.

* **setup.sh**
  - Update LXC IDs to 100, 101, 102, and 103.
  - Adjust the order of LXC IDs and names to match the new IDs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yakrel/proxmox-homelab-automation/pull/13?shareId=e78f6ecc-b65a-4769-8ee6-0e13b92f6766).