### PR TITLE
Translate Turkish comments and prompts to English

### DIFF
--- a/docker/proxy/docker-compose.yml
+++ b/docker/proxy/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     ports:
       - "53:53/tcp"
       - "53:53/udp"
-      - "3000:3000/tcp"  # Web arayüzü
+      - "3000:3000/tcp"  # Web interface
       - "8080:8080/tcp"  # HTTP redirect
     volumes:
       - /datapool/config/adguard-config/work:/opt/adguardhome/work
@@ -94,7 +94,7 @@ services:
       - /datapool/config/firefox-config:/config:rw
     environment:
       - TZ=Europe/Istanbul
-      - VNC_PASSWORD=${FIREFOX_VNC_PASSWORD:?Firefox VNC şifresi tanımlanmalıdır}
+      - VNC_PASSWORD=${FIREFOX_VNC_PASSWORD:?Firefox VNC password must be defined}
       - PUID=1000
       - PGID=1000
       - KEEP_APP_RUNNING=1

--- a/scripts/install_security.sh
+++ b/scripts/install_security.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-set -e  # Herhangi bir komut hata verdiğinde scripti durdur
+set -e  # Stop the script if any command fails
 
-# 1. Fail2ban Kurulumu
+# 1. Fail2ban Installation
 apt update
 apt install -y fail2ban
 
-# 2. Temel Yapılandırma
+# 2. Basic Configuration
 cp /etc/fail2ban/jail.conf /etc/fail2ban/jail.local
 
-# 3. Proxmox Filter Yapılandırması
+# 3. Proxmox Filter Configuration
 cat > /etc/fail2ban/filter.d/proxmox.conf << 'EOF'
 [Definition]
 failregex = pvedaemon\[.*authentication failure; rhost=<HOST> user=.* msg=.*
@@ -16,7 +16,7 @@ ignoreregex =
 journalmatch = _SYSTEMD_UNIT=pvedaemon.service
 EOF
 
-# 4. SSH ve Proxmox Jail Yapılandırması
+# 4. SSH and Proxmox Jail Configuration
 cat > /etc/fail2ban/jail.local << 'EOF'
 [sshd]
 backend = systemd
@@ -32,9 +32,9 @@ findtime = 2d
 bantime = 1h
 EOF
 
-# 5. Servisi Yeniden Başlat
+# 5. Restart the Service
 systemctl restart fail2ban
 
-# 6. Servis durumunu kontrol et
+# 6. Check the Service Status
 sleep 3
 systemctl status fail2ban

--- a/scripts/install_storage.sh
+++ b/scripts/install_storage.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-set -e  # Herhangi bir komut hata verdiğinde scripti durdur
+set -e  # Stop the script if any command fails
 
-# Samba kurulumu
+# Samba installation
 apt update
 apt install -y samba
 
-# Samba konfigürasyonu
+# Samba configuration
 cat >> /etc/samba/smb.conf << 'EOF'
 
 [datapool]
@@ -15,33 +15,33 @@ cat >> /etc/samba/smb.conf << 'EOF'
    force create mode = 0660
    force directory mode = 0770
    valid users = root
-   # Performans optimizasyonları
+   # Performance optimizations
    socket options = TCP_NODELAY IPTOS_LOWDELAY
    read raw = yes
    write raw = yes
    strict locking = no
 EOF
 
-# Root kullanıcısı için Samba şifresi belirleme
-echo "Lütfen Samba root şifresini girin:"
+# Set Samba password for root user
+echo "Please enter the Samba root password:"
 read -s samba_root_password
 (echo "$samba_root_password"; echo "$samba_root_password") | smbpasswd -a root
 
-# Servisi yeniden başlat
+# Restart the service
 systemctl restart smbd
 
-# Servis durumunu kontrol et
+# Check the service status
 sleep 3
 systemctl status smbd
 
-# Sanoid kurulumu
+# Sanoid installation
 apt update
 apt install -y sanoid
 
-# Sanoid config klasörünü oluştur
+# Create Sanoid config directory
 mkdir -p /etc/sanoid
 
-# Yapılandırma dosyasını oluştur
+# Create configuration file
 cat > /etc/sanoid/sanoid.conf << EOF
 [rpool/ROOT/pve-1]
         use_template = system
@@ -70,10 +70,10 @@ cat > /etc/sanoid/sanoid.conf << EOF
         autoprune = yes
 EOF
 
-# Servisi etkinleştir ve başlat
+# Enable and start the service
 systemctl enable sanoid.timer
 systemctl start sanoid.timer
 
-# Servis durumunu kontrol et
+# Check the service status
 sleep 3
 systemctl status sanoid.timer

--- a/scripts/setup_media_lxc.sh
+++ b/scripts/setup_media_lxc.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 set -e
 
-echo "Media LXC (ID: 101) hazırlığı yapılacak."
-read -p "Media LXC için klasörler oluşturulsun ve izinler ayarlansın mı? (y/N): " response
+echo "Media LXC (ID: 101) preparation will be done."
+read -p "Do you want to create folders and set permissions for Media LXC? (y/N): " response
 
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
-    # Dizin yapısını oluştur
+    # Create directory structure
     mkdir -p /datapool/config/{sonarr-config,radarr-config,bazarr-config,jellyfin-config,jellyseerr-config,qbittorrent-config,prowlarr-config,flaresolverr-config,watchtower-media-config,recyclarr-config,youtube-dl-config}
     mkdir -p /datapool/media/{tv,movies,youtube/{playlists,channels}}
     mkdir -p /datapool/torrents/{tv,movies}
     
-    # İzinleri ayarla (100000 varsayılan LXC UID/GID)
+    # Set permissions (100000 is the default LXC UID/GID)
     chown -R 100000:100000 /datapool/config/{sonarr-config,radarr-config,bazarr-config,jellyfin-config,jellyseerr-config,qbittorrent-config,prowlarr-config,flaresolverr-config,watchtower-media-config,recyclarr-config,youtube-dl-config}
     chown -R 100000:100000 /datapool/media
     chown -R 100000:100000 /datapool/torrents
     
-    # LXC'ye datapool'u bağla
+    # Mount datapool to LXC
     pct set 101 -mp0 /datapool,mp=/datapool
     
-    echo "Media LXC hazırlığı tamamlandı."
+    echo "Media LXC preparation completed."
 else
-    echo "İşlem iptal edildi."
+    echo "Operation cancelled."
 fi
 
 echo "-------------------------------------"
-echo "Şimdi LXC'nin içine geçip Docker ve Docker Compose'u yükleyin:"
+echo "Now enter the LXC and install Docker and Docker Compose:"
 echo "pct enter 101"
 echo ""
-echo "Ardından docker-compose.yml dosyasını kopyalayıp çalıştırın."
+echo "Then copy and run the docker-compose.yml file."
 echo "-------------------------------------"

--- a/scripts/setup_proxy_lxc.sh
+++ b/scripts/setup_proxy_lxc.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -e
 
-echo "Proxy LXC (ID: 100) hazırlığı yapılacak."
-read -p "Proxy LXC için klasörler oluşturulsun ve izinler ayarlansın mı? (y/N): " response
+echo "Proxy LXC (ID: 100) preparation will be done."
+read -p "Do you want to create folders and set permissions for Proxy LXC? (y/N): " response
 
 if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
-    # Dizin yapısını oluştur
+    # Create directory structure
     mkdir -p /datapool/config/{cloudflared-config,watchtower-proxy-config,adguard-config/{work,conf},firefox-config}
     
-    # İzinleri ayarla (100000 varsayılan LXC UID/GID)
+    # Set permissions (100000 is the default LXC UID/GID)
     chown -R 100000:100000 /datapool/config/{cloudflared-config,watchtower-proxy-config,adguard-config,firefox-config}
     
-    # LXC'ye datapool'u bağla
+    # Mount datapool to LXC
     pct set 100 -mp0 /datapool,mp=/datapool
     
-    echo "Proxy LXC hazırlığı tamamlandı."
+    echo "Proxy LXC preparation completed."
 else
-    echo "İşlem iptal edildi."
+    echo "Operation cancelled."
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,81 +1,81 @@
 #!/bin/bash
 
-# Başlık
+# Title
 echo "======================================================"
-echo "Proxmox Homelab Automation - Kurulum Aracı"
+echo "Proxmox Homelab Automation - Setup Tool"
 echo "======================================================"
 
-# Root kontrolü
+# Root check
 if [ "$(id -u)" -ne 0 ]; then
-   echo "Bu script root olarak çalıştırılmalıdır" 
+   echo "This script must be run as root" 
    exit 1
 fi
 
-# Geçici çalışma dizini
+# Temporary working directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-echo "Script dosyalarını $SCRIPT_DIR/scripts/ konumundan alıyorum."
+echo "Fetching script files from $SCRIPT_DIR/scripts/."
 
-# Menü
+# Menu
 echo ""
-echo "Lütfen yapmak istediğiniz işlemi seçin:"
-echo "1) Güvenlik Kurulumu (Fail2Ban)"
-echo "2) Depolama Kurulumu (Samba, Sanoid)"
-echo "3) Proxy LXC (ID: 100) Hazırlama"
-echo "4) Media LXC (ID: 101) Hazırlama"
-echo "5) Çıkış"
+echo "Please select the operation you want to perform:"
+echo "1) Security Installation (Fail2Ban)"
+echo "2) Storage Installation (Samba, Sanoid)"
+echo "3) Proxy LXC (ID: 100) Preparation"
+echo "4) Media LXC (ID: 101) Preparation"
+echo "5) Exit"
 echo ""
 
-read -p "Seçiminiz (1-5): " choice
+read -p "Your choice (1-5): " choice
 
 case $choice in
     1)
-        # Güvenlik kurulumu
+        # Security installation
         if [ -f "$SCRIPT_DIR/scripts/install_security.sh" ]; then
-            echo "Güvenlik kurulumu başlatılıyor..."
+            echo "Starting security installation..."
             bash "$SCRIPT_DIR/scripts/install_security.sh"
         else
-            echo "HATA: $SCRIPT_DIR/scripts/install_security.sh dosyası bulunamadı!"
+            echo "ERROR: $SCRIPT_DIR/scripts/install_security.sh file not found!"
         fi
         ;;
     2)
-        # Depolama kurulumu
+        # Storage installation
         if [ -f "$SCRIPT_DIR/scripts/install_storage.sh" ]; then
-            echo "Depolama kurulumu başlatılıyor..."
+            echo "Starting storage installation..."
             bash "$SCRIPT_DIR/scripts/install_storage.sh"
         else
-            echo "HATA: $SCRIPT_DIR/scripts/install_storage.sh dosyası bulunamadı!"
+            echo "ERROR: $SCRIPT_DIR/scripts/install_storage.sh file not found!"
         fi
         ;;
     3)
-        # Proxy LXC hazırlama
+        # Proxy LXC preparation
         if [ -f "$SCRIPT_DIR/scripts/setup_proxy_lxc.sh" ]; then
-            echo "Proxy LXC hazırlama başlatılıyor..."
+            echo "Starting Proxy LXC preparation..."
             bash "$SCRIPT_DIR/scripts/setup_proxy_lxc.sh"
         else
-            echo "HATA: $SCRIPT_DIR/scripts/setup_proxy_lxc.sh dosyası bulunamadı!"
+            echo "ERROR: $SCRIPT_DIR/scripts/setup_proxy_lxc.sh file not found!"
         fi
         ;;
     4)
-        # Media LXC hazırlama
+        # Media LXC preparation
         if [ -f "$SCRIPT_DIR/scripts/setup_media_lxc.sh" ]; then
-            echo "Media LXC hazırlama başlatılıyor..."
+            echo "Starting Media LXC preparation..."
             bash "$SCRIPT_DIR/scripts/setup_media_lxc.sh"
         else
-            echo "HATA: $SCRIPT_DIR/scripts/setup_media_lxc.sh dosyası bulunamadı!"
+            echo "ERROR: $SCRIPT_DIR/scripts/setup_media_lxc.sh file not found!"
         fi
         ;;
     5)
-        # Çıkış
-        echo "Çıkış yapılıyor..."
+        # Exit
+        echo "Exiting..."
         exit 0
         ;;
     *)
-        echo "Geçersiz seçim!"
+        echo "Invalid choice!"
         exit 1
         ;;
 esac
 
 echo "======================================================"
-echo "İşlem tamamlandı!"
+echo "Operation completed!"
 echo "======================================================"
 exit 0


### PR DESCRIPTION
Translate comments, environment variable descriptions, and user prompts from Turkish to English in various scripts and configuration files.

* **docker/proxy/docker-compose.yml**
  - Translate the comment for the web interface port.
  - Translate the environment variable description for `FIREFOX_VNC_PASSWORD`.

* **scripts/install_security.sh**
  - Translate the comment section at the top.
  - Translate all comments in the script.

* **scripts/install_storage.sh**
  - Translate the comment section at the top.
  - Translate all comments in the script.
  - Translate the user prompt for Samba root password.

* **scripts/setup_media_lxc.sh**
  - Translate the comment section at the top.
  - Translate all comments in the script.
  - Translate user prompts.

* **scripts/setup_proxy_lxc.sh**
  - Translate the comment section at the top.
  - Translate all comments in the script.
  - Translate user prompts.

* **setup.sh**
  - Translate the comment section at the top.
  - Translate all comments in the script.
  - Translate user prompts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yakrel/proxmox-homelab-automation/pull/14?shareId=5b1fd9ca-dd32-4c9c-a824-24cc993910cb).