### PR TITLE
Fix file permissions and remove incomplete folder

### DIFF
--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -6,13 +6,13 @@
 #    # Create directory structure
 #    mkdir -p /datapool/config/{sonarr,radarr,bazarr,jellyfin,jellyseerr,qbittorrent,prowlarr,flaresolverr,watchtower-media,recyclarr,metube}
 #    mkdir -p /datapool/media/{tv,movies,youtube/{playlists,channels}}
-#    mkdir -p /datapool/torrents/{tv,movies,incomplete}
+#    mkdir -p /datapool/torrents/{tv,movies}
 #    
 #    # Set LXC ownership (100000 is the recommended UID/GID for Docker containers)
 #    # Only set ownership for directories needed by this LXC
-#    chown -R 100000:100000 /datapool/config/{sonarr,radarr,bazarr,jellyfin,jellyseerr,qbittorrent,prowlarr,flaresolverr,watchtower-media,recyclarr,metube}
-#    chown -R 100000:100000 /datapool/media
-#    chown -R 100000:100000 /datapool/torrents
+#    chown -R 101000:101000 /datapool/config/{sonarr,radarr,bazarr,jellyfin,jellyseerr,qbittorrent,prowlarr,flaresolverr,watchtower-media,recyclarr,metube}
+#    chown -R 101000:101000 /datapool/media
+#    chown -R 101000:101000 /datapool/torrents
 #    
 #    # Mount datapool to LXC
 #    pct set 101 -mp0 /datapool,mp=/datapool

--- a/scripts/setup_media_lxc.sh
+++ b/scripts/setup_media_lxc.sh
@@ -27,12 +27,11 @@ if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
     # Create torrents directories
     mkdir -p /datapool/torrents/tv
     mkdir -p /datapool/torrents/movies
-    mkdir -p /datapool/torrents/incomplete
     
     # Set ownership for main directories only
-    chown -R 100000:100000 /datapool/config
-    chown -R 100000:100000 /datapool/media
-    chown -R 100000:100000 /datapool/torrents
+    chown -R 101000:101000 /datapool/config
+    chown -R 101000:101000 /datapool/media
+    chown -R 101000:101000 /datapool/torrents
     
     # Mount datapool to LXC
     pct set 101 -mp0 /datapool,mp=/datapool


### PR DESCRIPTION
Update file permissions and remove incomplete folder in torrents directory.

* Change ownership from 100000:100000 to 101000:101000 for `/datapool/config`, `/datapool/media`, and `/datapool/torrents` in `docker/media/docker-compose.yml`.
* Remove the `incomplete` folder from the `torrents` directory in `docker/media/docker-compose.yml`.
* Change ownership from 100000:100000 to 101000:101000 for `/datapool/config`, `/datapool/media`, and `/datapool/torrents` in `scripts/setup_media_lxc.sh`.
* Remove the `incomplete` folder from the `torrents` directory in `scripts/setup_media_lxc.sh`.
* Remove the `mkdir -p /datapool/torrents/incomplete` command in `scripts/setup_media_lxc.sh`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yakrel/proxmox-homelab-automation/pull/15?shareId=2460378b-a9ba-413b-afb6-15f44d05da8c).