### PR TITLE
Add VNC password to jdownloader2 service

### DIFF
--- a/docker/media/.env.example
+++ b/docker/media/.env.example
@@ -1,0 +1,1 @@
+JDOWNLOADER_VNC_PASSWORD=your_jdownloader_vnc_password_here

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -261,12 +261,10 @@ services:
       - PGID=1000
       - UMASK=002
       - TZ=Europe/Istanbul
-      # - JDOWNLOADER_MYJD_EMAIL= # Optional: Your MyJDownloader email
-      # - JDOWNLOADER_MYJD_PASSWORD= # Optional: Your MyJDownloader password
-      # - JDOWNLOADER_MYJD_DEVICE_NAME=homelab # Optional: Device name for MyJDownloader
       - KEEP_APP_RUNNING=1
       - DISPLAY_WIDTH=1280
       - DISPLAY_HEIGHT=768
+      - VNC_PASSWORD=${JDOWNLOADER_VNC_PASSWORD:?JDownloader VNC password must be defined}
     volumes:
       - /datapool/config/jdownloader2:/config
       - /datapool:/datapool


### PR DESCRIPTION
Update `docker/media/docker-compose.yml` to remove comments and add VNC password environment variable.

* Remove commented-out environment variables for MyJDownloader email, password, and device name from the `jdownloader2` service.
* Add the `VNC_PASSWORD` environment variable to the `jdownloader2` service, set to `${JDOWNLOADER_VNC_PASSWORD:?JDownloader VNC password must be defined}`.
* Add `docker/media/.env.example` file with the `JDOWNLOADER_VNC_PASSWORD` environment variable placeholder.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yakrel/proxmox-homelab-automation/pull/16?shareId=752f38bd-a71e-4408-9f17-47097c62f658).