### PR TITLE
Improve architecture with production-ready best practices

### DIFF
--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -28,6 +28,19 @@ services:
     networks:
       - media-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: '0.5'
+        reservations:
+          memory: 256M
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8989/ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     logging:
       driver: "json-file"
       options:
@@ -142,6 +155,19 @@ services:
     networks:
       - media-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.0'
+        reservations:
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v2/app/version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     logging:
       driver: "json-file"
       options:

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     container_name: cadvisor
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "8081:8080"
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
@@ -111,6 +111,19 @@ services:
       - TZ=Europe/Istanbul
     networks:
       - monitoring-net
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.3'
+        reservations:
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     logging:
       driver: "json-file"
       options:

--- a/scripts/automation/create_alpine_lxc.sh
+++ b/scripts/automation/create_alpine_lxc.sh
@@ -137,62 +137,103 @@ prepare_media_directories() {
     local lxc_id=$1
     print_info "Preparing media stack directories..."
     
-    # Create directories (same as existing setup_media_lxc.sh)
-    mkdir -p /datapool/config/{sonarr,radarr,bazarr,jellyfin,jellyseerr,qbittorrent,prowlarr,flaresolverr,watchtower-media,recyclarr,cleanuperr,huntarr}
+    # Configuration variables
+    local PUID=1000
+    local PGID=1000
+    
+    # Directory arrays for bulk operations
+    local CONFIG_DIRS=("sonarr" "radarr" "bazarr" "jellyfin" "jellyseerr" "qbittorrent" "prowlarr" "flaresolverr" "watchtower-media" "recyclarr" "cleanuperr" "huntarr")
+    
+    # Create config directories
+    for dir in "${CONFIG_DIRS[@]}"; do
+        mkdir -p "/datapool/config/$dir"
+        chown -R "${PUID}:${PGID}" "/datapool/config/$dir"
+    done
+    
+    # Create media and torrent directories
     mkdir -p /datapool/media/{tv,movies}
     mkdir -p /datapool/media/youtube/{playlists,channels}
     mkdir -p /datapool/torrents/{tv,movies,other}
     
-    # Set ownership (mapped UID for LXC 101)
-    chown -R 101000:101000 /datapool/config/{sonarr,radarr,bazarr,jellyfin,jellyseerr,qbittorrent,prowlarr,flaresolverr,watchtower-media,recyclarr,cleanuperr,huntarr}
-    chown -R 101000:101000 /datapool/media
-    chown -R 101000:101000 /datapool/torrents
+    # Set unified ownership
+    chown -R "${PUID}:${PGID}" /datapool/media
+    chown -R "${PUID}:${PGID}" /datapool/torrents
 }
 
 prepare_proxy_directories() {
     local lxc_id=$1
     print_info "Preparing proxy stack directories..."
     
-    # Create directories (same as existing setup_proxy_lxc.sh)
-    mkdir -p /datapool/config/{cloudflared,watchtower-proxy}
+    # Configuration variables
+    local PUID=1000
+    local PGID=1000
     
-    # Set ownership (mapped UID for LXC 100)
-    chown -R 100000:100000 /datapool/config/{cloudflared,watchtower-proxy}
+    # Directory arrays for bulk operations
+    local CONFIG_DIRS=("cloudflared" "watchtower-proxy")
+    
+    # Create config directories
+    for dir in "${CONFIG_DIRS[@]}"; do
+        mkdir -p "/datapool/config/$dir"
+        chown -R "${PUID}:${PGID}" "/datapool/config/$dir"
+    done
 }
 
 prepare_downloads_directories() {
     local lxc_id=$1
     print_info "Preparing downloads stack directories..."
     
-    # Create directories for downloads stack
-    mkdir -p /datapool/config/{jdownloader2,metube,watchtower-downloads}
+    # Configuration variables
+    local PUID=1000
+    local PGID=1000
     
-    # Set ownership (mapped UID for LXC 102)
-    chown -R 102000:102000 /datapool/config/{jdownloader2,metube,watchtower-downloads}
+    # Directory arrays for bulk operations
+    local CONFIG_DIRS=("jdownloader2" "metube" "watchtower-downloads")
+    
+    # Create config directories
+    for dir in "${CONFIG_DIRS[@]}"; do
+        mkdir -p "/datapool/config/$dir"
+        chown -R "${PUID}:${PGID}" "/datapool/config/$dir"
+    done
 }
 
 prepare_utility_directories() {
     local lxc_id=$1
     print_info "Preparing utility stack directories..."
     
-    # Create directories for utility stack
-    mkdir -p /datapool/config/{firefox,watchtower-utility}
+    # Configuration variables
+    local PUID=1000
+    local PGID=1000
     
-    # Set ownership (mapped UID for LXC 103)
-    chown -R 103000:103000 /datapool/config/{firefox,watchtower-utility}
+    # Directory arrays for bulk operations
+    local CONFIG_DIRS=("firefox" "watchtower-utility")
+    
+    # Create config directories
+    for dir in "${CONFIG_DIRS[@]}"; do
+        mkdir -p "/datapool/config/$dir"
+        chown -R "${PUID}:${PGID}" "/datapool/config/$dir"
+    done
 }
 
 prepare_monitoring_directories() {
     local lxc_id=$1
     print_info "Preparing monitoring stack directories..."
     
-    # Create directories for monitoring stack
-    mkdir -p /datapool/config/{prometheus,grafana,alertmanager,watchtower-monitoring}
-    mkdir -p /datapool/config/monitoring/{prometheus,grafana/provisioning,alertmanager}
+    # Configuration variables
+    local PUID=1000
+    local PGID=1000
     
-    # Set ownership (mapped UID for LXC 104) - containers will use PUID=1000
-    chown -R 104000:104000 /datapool/config/{prometheus,grafana,alertmanager,watchtower-monitoring}
-    chown -R 104000:104000 /datapool/config/monitoring
+    # Directory arrays for bulk operations
+    local CONFIG_DIRS=("prometheus" "grafana" "alertmanager" "watchtower-monitoring")
+    
+    # Create config directories
+    for dir in "${CONFIG_DIRS[@]}"; do
+        mkdir -p "/datapool/config/$dir"
+        chown -R "${PUID}:${PGID}" "/datapool/config/$dir"
+    done
+    
+    # Create monitoring specific directories
+    mkdir -p /datapool/config/monitoring/{prometheus,grafana/provisioning,alertmanager}
+    chown -R "${PUID}:${PGID}" /datapool/config/monitoring
 }
 
 # Main function to create complete LXC setup

--- a/scripts/automation/interactive_setup.sh
+++ b/scripts/automation/interactive_setup.sh
@@ -96,8 +96,9 @@ setup_proxy_env() {
 CLOUDFLARED_TOKEN=$cloudflare_token"
     
     create_common_env_content "Proxy" "$proxy_content" > "$stack_dir/.env"
+    chmod 600 "$stack_dir/.env"
     
-    print_info "✓ Proxy stack .env file created successfully"
+    print_info "✓ Proxy stack .env file created successfully with secure permissions"
     return 0
 }
 
@@ -112,8 +113,9 @@ setup_media_env() {
 # All services use web-based configuration interfaces"
     
     create_common_env_content "Media" "$media_content" > "$stack_dir/.env"
+    chmod 600 "$stack_dir/.env"
     
-    print_info "✓ Media stack .env file created successfully"
+    print_info "✓ Media stack .env file created successfully with secure permissions"
     print_info "Configure services through their web UIs after deployment"
     return 0
 }
@@ -132,8 +134,9 @@ setup_downloads_env() {
 JDOWNLOADER_VNC_PASSWORD=$jdownloader_password"
     
     create_common_env_content "Downloads" "$downloads_content" > "$stack_dir/.env"
+    chmod 600 "$stack_dir/.env"
     
-    print_info "✓ Downloads stack .env file created successfully"
+    print_info "✓ Downloads stack .env file created successfully with secure permissions"
     return 0
 }
 
@@ -151,8 +154,9 @@ setup_utility_env() {
 FIREFOX_VNC_PASSWORD=$firefox_password"
     
     create_common_env_content "Utility" "$utility_content" > "$stack_dir/.env"
+    chmod 600 "$stack_dir/.env"
     
-    print_info "✓ Utility stack .env file created successfully"
+    print_info "✓ Utility stack .env file created successfully with secure permissions"
     return 0
 }
 
@@ -184,8 +188,9 @@ PVE_URL=$pve_url
 PVE_VERIFY_SSL=false"
     
     create_common_env_content "Monitoring" "$monitoring_content" > "$stack_dir/.env"
+    chmod 600 "$stack_dir/.env"
     
-    print_info "✓ Monitoring stack .env file created successfully"
+    print_info "✓ Monitoring stack .env file created successfully with secure permissions"
     print_warning "Remember to create 'monitoring@pve' user in Proxmox with PVEAuditor role"
     return 0
 }


### PR DESCRIPTION
## Summary
• Standardized PUID/PGID approach across all automation scripts for consistency
• Added container resource limits and health checks for better reliability  
• Enhanced security with proper .env file permissions
• Fixed port conflicts and improved maintainability

## Key Changes

### 🔧 **PUID/PGID Standardization**
- Unified all `create_alpine_lxc.sh` functions to use PUID/PGID=1000
- Replaced inconsistent LXC-specific mappings (100000, 101000, etc.)
- Implemented array-based directory management pattern for better maintainability

### 🚀 **Container Resource Management** 
- **Sonarr**: 512MB memory limit, 0.5 CPU cores
- **qBittorrent**: 1GB memory limit, 1.0 CPU cores
- **cAdvisor**: 256MB memory limit, 0.3 CPU cores
- Added memory reservations for guaranteed baseline resources

### 🏥 **Health Check Implementation**
- **Sonarr**: `/ping` endpoint monitoring (30s interval)
- **qBittorrent**: API version endpoint validation
- **cAdvisor**: `/healthz` endpoint monitoring  
- 3 retries with 30s start period for reliable service monitoring

### 🔒 **Security Enhancements**
- Environment files now created with `chmod 600` permissions
- All `.env` files containing passwords protected from unauthorized access
- Consistent security implementation across all stack setup functions

### 🐛 **Port Conflict Resolution**
- Fixed cAdvisor port mapping: `8080` → `8081` in monitoring stack
- Prevents overlap with qBittorrent while maintaining service accessibility

## Test Plan
- [ ] Verify unified PUID/PGID approach works across all LXC stacks
- [ ] Test resource limits don't impact service functionality
- [ ] Confirm health checks properly detect service status
- [ ] Validate .env file permissions are correctly applied
- [ ] Test cAdvisor accessibility on new port 8081

🤖 Generated with [Claude Code](https://claude.ai/code)