### PR TITLE
Add comprehensive cleanuperr configuration for media stack

### DIFF
--- a/docker/media/.env.example
+++ b/docker/media/.env.example
@@ -8,11 +8,24 @@ TZ=Europe/Istanbul
 PUID=1000
 PGID=1000
 
-# No additional passwords required for media stack
-# All services use web-based configuration interfaces
+# Cleanuperr Configuration (Optional - for advanced automation)
+# Get these values after setting up Sonarr, Radarr, and qBittorrent
+# Leave commented out until you have the actual values
+
+# Sonarr API Key (get from: Settings > General > API Key)
+#SONARR_API_KEY=your_sonarr_api_key_here
+
+# Radarr API Key (get from: Settings > General > API Key)  
+#RADARR_API_KEY=your_radarr_api_key_here
+
+# qBittorrent Credentials (default username is usually 'admin')
+#QB_USERNAME=admin
+#QB_PASSWORD=your_qbittorrent_password_here
+
 # Configure services through their respective web UIs:
 # - Sonarr: http://your-ip:8989
 # - Radarr: http://your-ip:7878
 # - Jellyfin: http://your-ip:8096
 # - qBittorrent: http://your-ip:8080 (default: admin/adminadmin)
 # - Prowlarr: http://your-ip:9696
+# - Cleanuperr: http://your-ip:9555 (after configuring API keys)

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -274,6 +274,35 @@ services:
       - PGID=1000
       - UMASK=002
       - TZ=Europe/Istanbul
+      # Queue Cleaner Settings
+      - QUEUECLEANER__ENABLED=true
+      - QUEUECLEANER__RUNSEQUENTIALLY=true
+      - QUEUECLEANER__IMPORT_FAILED_MAX_STRIKES=5
+      - QUEUECLEANER__STALLED_MAX_STRIKES=3
+      # Sonarr Configuration
+      - SONARR__ENABLED=true
+      - SONARR__INSTANCES__0__URL=http://sonarr:8989
+      - SONARR__INSTANCES__0__APIKEY=${SONARR_API_KEY}
+      - SONARR__IMPORT_FAILED_MAX_STRIKES=3
+      - SONARR__SEARCHTYPE=Episode
+      # Radarr Configuration
+      - RADARR__ENABLED=true
+      - RADARR__INSTANCES__0__URL=http://radarr:7878
+      - RADARR__INSTANCES__0__APIKEY=${RADARR_API_KEY}
+      - RADARR__IMPORT_FAILED_MAX_STRIKES=3
+      - RADARR__SEARCHTYPE=Movie
+      # qBittorrent Configuration
+      - QBITTORRENT__ENABLED=true
+      - QBITTORRENT__URL=http://qbittorrent:8080
+      - QBITTORRENT__USERNAME=${QB_USERNAME}
+      - QBITTORRENT__PASSWORD=${QB_PASSWORD}
+      # Content Blocker
+      - CONTENTBLOCKER__ENABLED=true
+      - CONTENTBLOCKER__BLACKLIST__ENABLED=true
+      - CONTENTBLOCKER__BLACKLIST__PATH=https://raw.githubusercontent.com/flmorg/cleanuperr/refs/heads/main/blacklist
+      # Scheduling (30 min intervals for queue cleaner)
+      - SCHEDULES__QUEUECLEANER=0 */30 * * * *
+      - SCHEDULES__CONTENTBLOCKER=0 0 */6 * * *
     volumes:
       - /datapool/config/cleanuperr:/config
       - /datapool:/datapool
@@ -282,6 +311,10 @@ services:
     networks:
       - media-net
     restart: unless-stopped
+    depends_on:
+      - sonarr
+      - radarr
+      - qbittorrent
     logging:
       driver: "json-file"
       options:

--- a/scripts/automation/deploy_stack.sh
+++ b/scripts/automation/deploy_stack.sh
@@ -751,6 +751,21 @@ deploy_complete_stack() {
         # Show important notes
         print_info "Stack deployed successfully to $target_dir"
         
+        # Add stack-specific configuration notes
+        if [ "$stack_type" = "media" ]; then
+            echo
+            print_info "📝 Cleanuperr Configuration Required:"
+            print_info "   1. Access web interfaces to get API keys:"
+            print_info "      • Sonarr: http://[LXC-IP]:8989 → Settings > General > API Key"
+            print_info "      • Radarr: http://[LXC-IP]:7878 → Settings > General > API Key"
+            print_info "   2. Copy environment template: cp /opt/media/.env.example /opt/media/.env"
+            print_info "   3. Edit /opt/media/.env with your API keys and qBittorrent password"
+            print_info "   4. Restart cleanuperr: docker compose up -d --force-recreate cleanuperr"
+            print_info "   5. Access cleanuperr at: http://[LXC-IP]:9555"
+            echo
+            print_warning "⚠️  Cleanuperr won't function properly until configured with API keys!"
+        fi
+        
         return 0
     else
         print_error "Failed to deploy $stack_type stack"

--- a/scripts/automation/interactive_setup.sh
+++ b/scripts/automation/interactive_setup.sh
@@ -195,6 +195,8 @@ setup_media_env() {
     
     print_info "✓ Media stack .env file created successfully with secure permissions"
     print_info "Configure services through their web UIs after deployment"
+    print_warning "REMINDER: Configure cleanuperr for automated cleanup after deployment"
+    print_info "  Get API keys from Sonarr/Radarr, update .env file, then access cleanuperr at http://container-ip:9555"
     return 0
 }
 


### PR DESCRIPTION
## Summary
- Configure cleanuperr with proper environment variables for Sonarr, Radarr, and qBittorrent integration
- Add comprehensive post-deployment instructions for users to configure API keys
- Set conservative cleanup parameters to prevent aggressive deletion

## Changes Made
- **Docker Compose**: Added complete cleanuperr environment variables with API key placeholders
- **.env.example**: Updated template with cleanuperr configuration instructions
- **deploy_stack.sh**: Added detailed post-deployment configuration notes for media stack
- **interactive_setup.sh**: Added reminder about cleanuperr configuration

## Configuration Features
- Conservative strike limits (3-5 strikes) to prevent false positives
- Content blocking with official blacklist for malicious files
- Scheduled cleanup: queue every 30 min, content blocking every 6 hours
- Secure credential management via environment variables

## Test plan
- [ ] Deploy media stack and verify cleanuperr starts without errors
- [ ] Verify configuration instructions appear after deployment
- [ ] Test API key configuration workflow
- [ ] Confirm cleanuperr functions properly with configured credentials

🤖 Generated with [Claude Code](https://claude.ai/code)