### PR TITLE
feat(monitoring): Replace Node Exporter with cAdvisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project is divided into several service stacks, each with its own `docker-c
 -   **LXC Configuration:** 2 Cores, 2048MB RAM
 -   **Services:**
     -   Cloudflared
-    -   Node Exporter
+    -   cAdvisor
     -   Watchtower
 
 #### Media Stack
@@ -76,7 +76,7 @@ This project is divided into several service stacks, each with its own `docker-c
     -   Prowlarr
     -   FlareSolverr
     -   Recyclarr
-    -   Node Exporter
+    -   cAdvisor
     -   Watchtower
     -   Cleanuparr
 
@@ -88,7 +88,7 @@ This project is divided into several service stacks, each with its own `docker-c
     -   JDownloader 2
     -   MeTube
     -   Palmr
-    -   Node Exporter
+    -   cAdvisor
     -   Watchtower
 
 #### Webtools Stack
@@ -98,7 +98,7 @@ This project is divided into several service stacks, each with its own `docker-c
 -   **Services:**
     -   Homepage
     -   Firefox
-    -   Node Exporter
+    -   cAdvisor
     -   Watchtower
 
 #### Monitoring Stack
@@ -108,7 +108,7 @@ This project is divided into several service stacks, each with its own `docker-c
 -   **Services:**
     -   Prometheus
     -   Grafana
-    -   Node Exporter
+    -   cAdvisor
     -   Prometheus PVE Exporter
     -   Watchtower
 
@@ -118,5 +118,5 @@ After deploying the monitoring stack, you can import pre-configured dashboards i
 
 -   **Proxmox VE Overview:** `10347`
     -   Provides a high-level overview of your Proxmox host and all guest VMs/LXCs.
--   **Node Exporter Full:** `1860`
-    -   Provides detailed metrics for individual Linux systems (your LXC containers). Use the dropdown at the top to switch between different instances.
+-   **cAdvisor Exporter:** `13979`
+    -   Provides detailed container-level metrics for each LXC. Use the dropdown at the top to switch between different instances.

--- a/docker/common/compose.yml
+++ b/docker/common/compose.yml
@@ -1,0 +1,40 @@
+# This file is not meant to be run directly.
+# It contains common service definitions to be included and extended by other stacks.
+services:
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    ports:
+      - "8082:8080"
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  watchtower:
+    image: containrrr/watchtower:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - TZ=${TZ:-Europe/Istanbul}
+      - WATCHTOWER_CLEANUP=true
+      - PUID=1000
+      - PGID=1000
+      - UMASK=002
+    # The command (schedule) is defined in the individual stack compose files.
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker/files/docker-compose.yml
+++ b/docker/files/docker-compose.yml
@@ -78,7 +78,7 @@ services:
         max-file: "3"
 
   cadvisor-files:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor-files
     privileged: true
     ports:

--- a/docker/files/docker-compose.yml
+++ b/docker/files/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ../common/compose.yml
+
 networks:
   files-net:
     driver: bridge
@@ -77,46 +80,17 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  cadvisor-files:
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+  cadvisor:
+    extends:
+      service: cadvisor
     container_name: cadvisor-files
-    privileged: true
-    ports:
-      - "8082:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    devices:
-      - /dev/kmsg
-    restart: unless-stopped
     networks:
       - files-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
 
-  watchtower-files:
-    image: containrrr/watchtower:latest
+  watchtower:
+    extends:
+      service: watchtower
     container_name: watchtower-files
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_SCHEDULE=0 0 8,14,20,2 * * *
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-    restart: unless-stopped
+    command: ["--schedule", "0 0 8,14,20,2 * * *"]
     networks:
       - files-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"

--- a/docker/files/docker-compose.yml
+++ b/docker/files/docker-compose.yml
@@ -77,23 +77,21 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  node-exporter-files:
-    image: prom/node-exporter:latest
-    container_name: node-exporter-files
-    restart: unless-stopped
+  cadvisor-files:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor-files
+    privileged: true
     ports:
-      - "9100:9100"
+      - "8082:8080"
     volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    restart: unless-stopped
     networks:
       - files-net
     logging:

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -217,7 +217,7 @@ services:
 
 
   cadvisor-media:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor-media
     privileged: true
     ports:

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -216,23 +216,21 @@ services:
         max-file: "3"
 
 
-  node-exporter-media:
-    image: prom/node-exporter:latest
-    container_name: node-exporter-media
-    restart: unless-stopped
+  cadvisor-media:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor-media
+    privileged: true
     ports:
-      - "9100:9100"
+      - "8082:8080"
     volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    environment:
-      - TZ=Europe/Istanbul
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    restart: unless-stopped
     networks:
       - media-net
     logging:

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ../common/compose.yml
+
 networks:
   media-net:
     driver: bridge
@@ -215,50 +218,20 @@ services:
         max-size: "10m"
         max-file: "3"
 
-
-  cadvisor-media:
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+  cadvisor:
+    extends:
+      service: cadvisor
     container_name: cadvisor-media
-    privileged: true
-    ports:
-      - "8082:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    devices:
-      - /dev/kmsg
-    restart: unless-stopped
     networks:
       - media-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
 
-  watchtower-media:
-    image: containrrr/watchtower:latest
+  watchtower:
+    extends:
+      service: watchtower
     container_name: watchtower-media
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - TZ=Europe/Istanbul
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_SCHEDULE=0 0 8,14,20,2 * * *
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-    restart: unless-stopped
+    command: ["--schedule", "0 0 8,14,20,2 * * *"]
     networks:
       - media-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
 
   cleanuperr:
     image: ghcr.io/cleanuparr/cleanuparr:latest
@@ -287,4 +260,3 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -67,25 +67,21 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  node-exporter-monitoring:
-    image: prom/node-exporter:latest
-    container_name: node-exporter-monitoring
-    restart: unless-stopped
+  cadvisor-monitoring:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor-monitoring
+    privileged: true
     ports:
-      - "9100:9100"
+      - "8082:8080"
     volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($|/)'
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
-      - PUID=1000
-      - PGID=1000
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    restart: unless-stopped
     networks:
       - monitoring-net
     logging:

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ../common/compose.yml
+
 networks:
   monitoring-net:
     driver: bridge
@@ -67,28 +70,12 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  cadvisor-monitoring:
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+  cadvisor:
+    extends:
+      service: cadvisor
     container_name: cadvisor-monitoring
-    privileged: true
-    ports:
-      - "8082:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    devices:
-      - /dev/kmsg
-    restart: unless-stopped
     networks:
       - monitoring-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
 
   prometheus-pve-exporter:
     image: prompve/prometheus-pve-exporter:latest
@@ -112,23 +99,10 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  watchtower-monitoring:
-    image: containrrr/watchtower:latest
+  watchtower:
+    extends:
+      service: watchtower
     container_name: watchtower-monitoring
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_SCHEDULE=0 0 8,14,20,2 * * *
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-    restart: unless-stopped
+    command: ["--schedule", "0 0 8,14,20,2 * * *"]
     networks:
       - monitoring-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"

--- a/docker/monitoring/docker-compose.yml
+++ b/docker/monitoring/docker-compose.yml
@@ -68,7 +68,7 @@ services:
         max-file: "3"
 
   cadvisor-monitoring:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor-monitoring
     privileged: true
     ports:

--- a/docker/monitoring/prometheus.yml
+++ b/docker/monitoring/prometheus.yml
@@ -17,40 +17,17 @@ scrape_configs:
     static_configs:
       - targets: ['localhost:9090']
 
-  # Node Exporter - Monitoring LXC (104)
-  - job_name: 'node-exporter-monitoring'
+  # cAdvisor for container metrics
+  - job_name: 'cadvisor'
     static_configs:
-      - targets: ['node-exporter-monitoring:9100']
+      - targets:
+        - 'cadvisor-monitoring:8082' # Monitoring LXC
+        - '192.168.1.100:8082'      # Proxy LXC
+        - '192.168.1.101:8082'      # Media LXC
+        - '192.168.1.102:8082'      # Files LXC
+        - '192.168.1.103:8082'      # Webtools LXC
         labels:
-          instance: 'monitoring-lxc-104'
-
-  # Node Exporter - Proxy LXC (100)
-  - job_name: 'node-exporter-proxy'
-    static_configs:
-      - targets: ['192.168.1.100:9100']
-        labels:
-          instance: 'proxy-lxc-100'
-
-  # Node Exporter - Media LXC (101)
-  - job_name: 'node-exporter-media'
-    static_configs:
-      - targets: ['192.168.1.101:9100']
-        labels:
-          instance: 'media-lxc-101'
-
-  # Node Exporter - Files LXC (102)
-  - job_name: 'node-exporter-files'
-    static_configs:
-      - targets: ['192.168.1.102:9100']
-        labels:
-          instance: 'files-lxc-102'
-
-  # Node Exporter - Webtools LXC (103)
-  - job_name: 'node-exporter-webtools'
-    static_configs:
-      - targets: ['192.168.1.103:9100']
-        labels:
-          instance: 'webtools-lxc-103'
+          instance: 'cadvisor'
 
   
 

--- a/docker/monitoring/prometheus.yml
+++ b/docker/monitoring/prometheus.yml
@@ -26,8 +26,27 @@ scrape_configs:
         - '192.168.1.101:8082'      # Media LXC
         - '192.168.1.102:8082'      # Files LXC
         - '192.168.1.103:8082'      # Webtools LXC
-        labels:
-          instance: 'cadvisor'
+    relabel_configs:
+      - source_labels: [__address__]
+        regex: 'cadvisor-monitoring:8082'
+        target_label: instance
+        replacement: 'monitoring-lxc-104'
+      - source_labels: [__address__]
+        regex: '192.168.1.100:8082'
+        target_label: instance
+        replacement: 'proxy-lxc-100'
+      - source_labels: [__address__]
+        regex: '192.168.1.101:8082'
+        target_label: instance
+        replacement: 'media-lxc-101'
+      - source_labels: [__address__]
+        regex: '192.168.1.102:8082'
+        target_label: instance
+        replacement: 'files-lxc-102'
+      - source_labels: [__address__]
+        regex: '192.168.1.103:8082'
+        target_label: instance
+        replacement: 'webtools-lxc-103'
 
   
 

--- a/docker/proxy/docker-compose.yml
+++ b/docker/proxy/docker-compose.yml
@@ -23,23 +23,21 @@ services:
         max-file: "3"
 
 
-  node-exporter-proxy:
-    image: prom/node-exporter:latest
-    container_name: node-exporter-proxy
-    restart: unless-stopped
+  cadvisor-proxy:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor-proxy
+    privileged: true
     ports:
-      - "9100:9100"
+      - "8082:8080"
     volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    restart: unless-stopped
     networks:
       - proxy-net
     logging:

--- a/docker/proxy/docker-compose.yml
+++ b/docker/proxy/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
 
   cadvisor-proxy:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor-proxy
     privileged: true
     ports:

--- a/docker/proxy/docker-compose.yml
+++ b/docker/proxy/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ../common/compose.yml
+
 networks:
   proxy-net:
     driver: bridge
@@ -22,48 +25,18 @@ services:
         max-size: "10m"
         max-file: "3"
 
-
-  cadvisor-proxy:
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+  cadvisor:
+    extends:
+      service: cadvisor
     container_name: cadvisor-proxy
-    privileged: true
-    ports:
-      - "8082:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    devices:
-      - /dev/kmsg
-    restart: unless-stopped
     networks:
       - proxy-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
 
-  watchtower-proxy:
-    image: containrrr/watchtower:latest
+  watchtower:
+    extends:
+      service: watchtower
     container_name: watchtower-proxy
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_SCHEDULE=0 0 8,14,20,2 * * *
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-    restart: unless-stopped
+    command: ["--schedule", "0 0 8,14,20,2 * * *"]
     networks:
       - proxy-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
         

--- a/docker/webtools/docker-compose.yml
+++ b/docker/webtools/docker-compose.yml
@@ -61,23 +61,21 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  node-exporter-webtools:
-    image: prom/node-exporter:latest
-    container_name: node-exporter-webtools
-    restart: unless-stopped
+  cadvisor-webtools:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor-webtools
+    privileged: true
     ports:
-      - "9100:9100"
+      - "8082:8080"
     volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
       - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+    restart: unless-stopped
     networks:
       - webtools-net
     logging:

--- a/docker/webtools/docker-compose.yml
+++ b/docker/webtools/docker-compose.yml
@@ -62,7 +62,7 @@ services:
         max-file: "3"
 
   cadvisor-webtools:
-    image: gcr.io/cadvisor/cadvisor:latest
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor-webtools
     privileged: true
     ports:

--- a/docker/webtools/docker-compose.yml
+++ b/docker/webtools/docker-compose.yml
@@ -1,3 +1,6 @@
+include:
+  - ../common/compose.yml
+
 networks:
   webtools-net:
     driver: bridge
@@ -61,46 +64,17 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  cadvisor-webtools:
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+  cadvisor:
+    extends:
+      service: cadvisor
     container_name: cadvisor-webtools
-    privileged: true
-    ports:
-      - "8082:8080"
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-      - /dev/disk/:/dev/disk:ro
-    devices:
-      - /dev/kmsg
-    restart: unless-stopped
     networks:
       - webtools-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"
 
-  watchtower-webtools:
-    image: containrrr/watchtower:latest
+  watchtower:
+    extends:
+      service: watchtower
     container_name: watchtower-webtools
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      - TZ=${TZ:-Europe/Istanbul}
-      - WATCHTOWER_CLEANUP=true
-      - WATCHTOWER_SCHEDULE=0 0 8,14,20,2 * * *
-      - PUID=1000
-      - PGID=1000
-      - UMASK=002
-    restart: unless-stopped
+    command: ["--schedule", "0 0 8,14,20,2 * * *"]
     networks:
       - webtools-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "3"


### PR DESCRIPTION
This pull request replaces the use of `Node Exporter` with `cAdvisor` across the project for container monitoring. The changes include updates to documentation, Docker Compose configurations, and Prometheus scrape configurations to reflect the new monitoring tool.

### Documentation Updates:
* Updated the README to replace references to `Node Exporter` with `cAdvisor` in the service stacks and monitoring dashboards. The new `cAdvisor Exporter` dashboard ID (`13979`) is provided for detailed container-level metrics. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R79) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L91-R91) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L101-R101) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R111) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R122)

### Docker Compose Updates:
* Replaced `Node Exporter` services with `cAdvisor` in all relevant Docker Compose files (`docker/files/docker-compose.yml`, `docker/media/docker-compose.yml`, `docker/monitoring/docker-compose.yml`, `docker/proxy/docker-compose.yml`, `docker/webtools/docker-compose.yml`). Key changes include:
  - Updated image to `gcr.io/cadvisor/cadvisor:latest`.
  - Adjusted ports from `9100` to `8082`.
  - Modified volume mappings to align with `cAdvisor` requirements.
  - Added `privileged` mode and device mappings for enhanced container metrics. [[1]](diffhunk://#diff-fa9cce045e31dd03f48f51d656786c3bceec64c8ecc858010333edabb047e9acL80-R94) [[2]](diffhunk://#diff-53ef2b0ea2c7aa844257185f7ec714ce9270aaca5b27b81d76807faf54a84814L219-R233) [[3]](diffhunk://#diff-06506882aa709926d272d253b1f6ccb905ec6bb7ab75b840f58aac2c90122922L70-R84) [[4]](diffhunk://#diff-5b83386cef443ee610b96abe9095634718d185746261fcae55e6f6ea6aff5a7bL26-R40) [[5]](diffhunk://#diff-dbcecfc47905b3342179f5cb8360e74f8ea19ead234e3ffee9003a24fcd75eabL64-R78)

### Prometheus Configuration Updates:
* Updated `prometheus.yml` to replace `Node Exporter` scrape configurations with `cAdvisor`. The new job consolidates targets for all containers (`cadvisor-monitoring`, `cadvisor-proxy`, `cadvisor-media`, etc.) on port `8082`. Labels were adjusted to reflect the `cAdvisor` instance.