### PR TITLE
Replace VAAPI drivers with GStreamer NVENC plugins for GTX 970 GPU en…

### DIFF
--- a/docker-images/desktop-workspace/Dockerfile
+++ b/docker-images/desktop-workspace/Dockerfile
@@ -31,9 +31,10 @@ RUN \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     google-chrome-stable=${CHROME_VERSION} \
-    nvidia-vaapi-driver \
-    va-driver-all \
-    vainfo && \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-tools && \
   echo "**** install Obsidian dependencies ****" && \
   apt-get install -y --no-install-recommends \
     chromium \


### PR DESCRIPTION
…coding

- Remove nvidia-vaapi-driver, va-driver-all, vainfo (VAAPI not working on GTX 970)
- Add gstreamer1.0-plugins-bad/ugly/good for NVENC support
- Add gstreamer1.0-tools for debugging
- Fixes "VAAPI init failed" error, enables proper NVENC hardware encoding
- Works with existing SELKIES_ENCODER=nvh264enc setting in docker-compose.yml

GTX 970 does not have proper VAAPI support but has full NVENC support through GStreamer nvh264enc plugin. This change enables GPU-accelerated encoding.