### PR TITLE
Add nvh264enc to Selkies allowed encoder list for GPU encoding

### DIFF
--- a/docker-images/desktop-workspace/Dockerfile
+++ b/docker-images/desktop-workspace/Dockerfile
@@ -35,6 +35,9 @@ RUN \
     gstreamer1.0-plugins-ugly \
     gstreamer1.0-plugins-good \
     gstreamer1.0-tools && \
+  echo "**** patch Selkies to add NVENC support ****" && \
+  sed -i "s/\\['x264enc', 'x264enc-striped', 'jpeg'\\]/['x264enc', 'x264enc-striped', 'jpeg', 'nvh264enc']/" \
+    /lsiopy/lib/python3.13/site-packages/selkies/settings.py && \
   echo "**** install Obsidian dependencies ****" && \
   apt-get install -y --no-install-recommends \
     chromium \


### PR DESCRIPTION
- Patch Selkies settings.py to add 'nvh264enc' to allowed encoder list
- Fixes "Invalid value(s) 'nvh264enc' for encoder" warning
- Enables NVENC GPU encoding via GStreamer nvh264enc plugin
- Works with SELKIES_ENCODER=nvh264enc environment variable

GTX 970 has full NVENC support through GStreamer. This patch allows Selkies to accept nvh264enc as a valid encoder choice, enabling GPU-accelerated H.264 encoding instead of falling back to CPU-based x264enc.