### PR TITLE
Remove CVE-2025-52881 workaround - fixed in lxc-pve 6.0.5-2+

### DIFF
--- a/scripts/lxc-manager.sh
+++ b/scripts/lxc-manager.sh
@@ -156,19 +156,6 @@ EOF
     fi
 fi
 
-# Fix for CVE-2025-52881: Docker/containerd sysctl permission denied in unprivileged LXC
-# Required for Docker containers that modify net.ipv4.ip_unprivileged_port_start
-# Affects: Docker 27.8.2+ / containerd 1.7.28+ with AppArmor in unprivileged LXC containers
-# This fix must be applied to ALL Docker-based stacks, not just GPU-enabled ones
-# Reference: https://github.com/opencontainers/runc/issues/4968
-if [[ "$STACK_NAME" != "development" ]]; then
-    LXC_CONFIG_PATH="/etc/pve/lxc/${CT_ID}.conf"
-    if ! grep -Fxq "lxc.apparmor.profile = unconfined" "$LXC_CONFIG_PATH"; then
-        echo "lxc.apparmor.profile = unconfined" >> "$LXC_CONFIG_PATH"
-        print_info "Applied AppArmor fix for Docker sysctl (CVE-2025-52881)"
-    fi
-fi
-
 # Ensure container is running
 CT_STATUS=$(pct status "$CT_ID" | awk '{print $2}')
 if [[ "$CT_STATUS" != "running" ]]; then


### PR DESCRIPTION
The AppArmor profile issue causing Docker containers to fail in unprivileged LXC has been officially fixed in lxc-pve 6.0.5-2+.

Since we require Proxmox VE 9.x (which includes this fix), the workaround (lxc.apparmor.profile = unconfined) is no longer needed.

The official fix provides proper AppArmor protection while allowing /proc/sys/ access for runc, making it more secure than our workaround.

Reference: https://github.com/opencontainers/runc/issues/4968