### PR TITLE
Refactor scripts to use local files

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -25,8 +25,6 @@ set -euo pipefail
 # --- Global Variables ---
 
 WORK_DIR=""
-get_repo_base_url() { echo "https://raw.githubusercontent.com/Yakrel/proxmox-homelab-automation/main"; }
-REPO_BASE_URL=$(get_repo_base_url)
 
 # --- Helper Functions ---
 

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -47,11 +47,16 @@ decrypt_env_for_deploy() {
 
     print_info "Decrypting environment for $stack"
 
-    local enc_url="$REPO_BASE_URL/docker/$stack/.env.enc"
+    local enc_file="$WORK_DIR/docker/$stack/.env.enc"
     local enc_tmp="$WORK_DIR/.env.enc"
     ENV_DECRYPTED_PATH="$WORK_DIR/.env"
 
-    curl -sSL "$enc_url" -o "$enc_tmp" || { print_error "Failed to download .env.enc"; exit 1; }
+    if [[ ! -f "$enc_file" ]]; then
+        print_error "Encrypted environment file not found at $enc_file"
+        exit 1
+    fi
+
+    cp "$enc_file" "$enc_tmp" || { print_error "Failed to copy .env.enc"; exit 1; }
 
     # Get passphrase and decrypt
     local pass

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -27,7 +27,6 @@ source "$WORK_DIR/scripts/modules/monitoring-deployment.sh"
 source "$WORK_DIR/scripts/modules/backup-deployment.sh"
 
 # --- Global Variables ---
-REPO_BASE_URL=$(get_repo_base_url)
 PVE_MONITORING_PASSWORD=""
 ENV_DECRYPTED_PATH=""
 

--- a/scripts/helper-functions.sh
+++ b/scripts/helper-functions.sh
@@ -326,33 +326,6 @@ decrypt_env_file() {
     fi
 }
 
-# Download, customize template, and push to LXC container
-download_customize_and_push() {
-    local ct_id="$1"
-    local remote_url="$2"
-    local target_path="$3"
-    local hostname="$4"
-    local temp_file="${5:-$WORK_DIR/$(basename "$remote_url")}"
-    
-    print_info "Downloading $(basename "$remote_url") template"
-    curl -sSL "$remote_url" -o "$temp_file"
-    
-    # Replace hostname placeholder
-    sed -i "s/REPLACE_HOST_LABEL/$hostname/g" "$temp_file"
-    
-    print_info "Pushing customized $(basename "$remote_url") to LXC $ct_id ($target_path)"
-    pct push "$ct_id" "$temp_file" "$target_path"
-    
-    rm -f "$temp_file"
-}
-
-# === REPOSITORY FUNCTIONS ===
-# Central repository URL management
-
-get_repo_base_url() {
-    echo "https://raw.githubusercontent.com/Yakrel/proxmox-homelab-automation/main"
-}
-
 # === VALIDATION FUNCTIONS ===
 # Common validation patterns
 

--- a/scripts/helper-functions.sh
+++ b/scripts/helper-functions.sh
@@ -287,20 +287,6 @@ backup_file() {
 
 # Download file and push to LXC container
 download_and_push_config() {
-    local ct_id="$1"
-    local remote_url="$2"
-    local target_path="$3"
-    local temp_file="${4:-$WORK_DIR/$(basename "$remote_url")}"
-    
-    print_info "Downloading $(basename "$remote_url")"
-    curl -sSL "$remote_url" -o "$temp_file"
-    
-    print_info "Pushing to LXC $ct_id ($target_path)"
-    pct push "$ct_id" "$temp_file" "$target_path"
-    
-    rm -f "$temp_file"
-}
-
 # Environment file encryption/decryption helpers
 encrypt_env_file() {
     local input_file="$1"

--- a/scripts/modules/docker-deployment.sh
+++ b/scripts/modules/docker-deployment.sh
@@ -18,38 +18,21 @@ setup_homepage_config() {
     # List of homepage config files to copy
     local config_files=("services.yaml" "bookmarks.yaml" "widgets.yaml" "settings.yaml" "docker.yaml")
 
-    # Download all files in parallel for better performance
-    local pids=()
+    # Copy all files from local workspace
     for config_file in "${config_files[@]}"; do
-        local config_url="$REPO_BASE_URL/config/homepage/$config_file"
-        local temp_file="/tmp/homepage_${config_file}"
+        local source_file="$WORK_DIR/config/homepage/$config_file"
+        local dest_file="/datapool/config/homepage/$config_file"
         
-        # Launch background curl job with explicit error handling
-        (
-            if curl -sSL "$config_url" -o "$temp_file"; then
-                if cp "$temp_file" "/datapool/config/homepage/$config_file"; then
-                    rm -f "$temp_file"
-                    exit 0
-                fi
-            fi
-            rm -f "$temp_file"  # Clean up temp file on any failure
+        if [[ -f "$source_file" ]]; then
+            cp "$source_file" "$dest_file" || {
+                print_error "Failed to copy $config_file"
+                exit 1
+            }
+        else
+            print_error "Source file not found: $source_file"
             exit 1
-        ) &
-        pids+=($!)
-    done
-    
-    # Wait for all downloads to complete and check for failures
-    local failed=0
-    for pid in "${pids[@]}"; do
-        if ! wait "$pid"; then
-            failed=1
         fi
     done
-    
-    if [[ $failed -eq 1 ]]; then
-        print_error "Failed to download homepage config files"
-        exit 1
-    fi
 
     # Fix permissions
     chown -R 101000:101000 /datapool/config/homepage
@@ -68,12 +51,18 @@ setup_couchdb_config() {
     mkdir -p /datapool/config/couchdb/local.d
 
     # Copy CouchDB configuration file
-    local config_url="$REPO_BASE_URL/config/couchdb-local.ini"
-    local temp_file="/tmp/couchdb_local.ini"
+    local source_file="$WORK_DIR/config/couchdb-local.ini"
+    local dest_file="/datapool/config/couchdb/local.d/local.ini"
 
-    curl -sSL "$config_url" -o "$temp_file"
-    cp "$temp_file" "/datapool/config/couchdb/local.d/local.ini"
-    rm -f "$temp_file"
+    if [[ -f "$source_file" ]]; then
+        cp "$source_file" "$dest_file" || {
+            print_error "Failed to copy couchdb-local.ini"
+            exit 1
+        }
+    else
+        print_error "Source file not found: $source_file"
+        exit 1
+    fi
 
     # Fix permissions
     chown -R 101000:101000 /datapool/config/couchdb


### PR DESCRIPTION
This PR refactors the deployment scripts (`deploy-stack.sh`, `docker-deployment.sh`, `monitoring-deployment.sh`) to use local files from the workspace (`$WORK_DIR`) instead of downloading them from the remote GitHub repository. This aligns with the recent change to `installer.sh` which downloads the entire repository as a tarball.

Benefits:
- Improves development workflow (no need to push to test changes).
- Ensures consistency between the installer and deployment scripts.
- Reduces unnecessary network traffic.