### PR TITLE
Add NixOS-style terminal to dev code-server

### DIFF
--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -25,6 +25,7 @@ STACK_NAME=$1
 # --- Load Deployment Modules ---
 source "$WORK_DIR/scripts/modules/docker-deployment.sh"
 source "$WORK_DIR/scripts/modules/backrest-deployment.sh"
+source "$WORK_DIR/scripts/modules/dev-terminal.sh"
 
 # --- Global Variables ---
 ENV_DECRYPTED_PATH=""
@@ -122,6 +123,9 @@ create_lxc
 
 # Step 4: Stack-specific pre-deployment
 case "$STACK_NAME" in
+    "dev")
+        deploy_dev_terminal "$CT_ID"
+        ;;
     "utility")
         deploy_backrest "$CT_ID"
         ;;

--- a/scripts/fast-redeploy.sh
+++ b/scripts/fast-redeploy.sh
@@ -9,6 +9,7 @@ WORK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 source "$WORK_DIR/scripts/helper-functions.sh"
 source "$WORK_DIR/scripts/modules/docker-deployment.sh"
 source "$WORK_DIR/scripts/modules/backrest-deployment.sh"
+source "$WORK_DIR/scripts/modules/dev-terminal.sh"
 
 ENV_ENC_KEY=""
 ENV_DECRYPTED_PATH=""
@@ -69,6 +70,7 @@ fast_redeploy_stack() {
 
         print_info "Fast redeploying dev CLI applications"
         bash "$WORK_DIR/scripts/lxc-manager.sh" dev
+        deploy_dev_terminal "$CT_ID"
         print_success "Fast redeployed: dev"
         return 0
     }

--- a/scripts/modules/dev-terminal.sh
+++ b/scripts/modules/dev-terminal.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+# Dev LXC terminal experience shared by full deploys and fast redeploys.
+# Keeps the Proxmox/root login shell on Bash while making code-server's
+# integrated terminal use Fish with the desktop's Tokyo Night palette.
+
+deploy_dev_terminal() {
+    local ct_id="$1"
+    local guest_script remote_script
+
+    guest_script=$(mktemp /tmp/dev-terminal-setup.XXXXXX)
+    register_runtime_temp_file "$guest_script"
+    remote_script="/tmp/dev-terminal-setup.sh"
+
+    cat > "$guest_script" <<'GUEST_SCRIPT'
+#!/bin/bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Keep the server lean: code-server is the terminal emulator, so only install
+# shell/CLI tooling. Kitty and desktop packages intentionally stay on NixOS.
+apt-get update -qq
+apt-get install -y -qq fish eza bat zoxide btop
+
+# Debian ships bat as /usr/bin/batcat. Match the NixOS command name so the same
+# Fish alias can be used on both systems.
+ln -sfn /usr/bin/batcat /usr/local/bin/bat
+
+install -d -m 0755 /root/.config/fish
+cat > /root/.config/fish/config.fish <<'FISH_CONFIG'
+if status is-interactive
+    set -g fish_greeting
+    set -gx PATH /root/.local/bin /usr/local/bin $PATH
+
+    alias ls 'eza --icons'
+    alias ll 'eza -lh --icons'
+    alias la 'eza -la --icons'
+    alias tree 'eza --tree --icons'
+    alias cat 'bat'
+
+    zoxide init fish | source
+end
+FISH_CONFIG
+
+# code-server stores machine-scoped settings under its data directory. That
+# directory is already symlinked to /fastpool/config/code-server/data, so these
+# settings persist without overwriting the user's editor preferences.
+install -d -m 0755 /root/.local/share/code-server/Machine
+cat > /root/.local/share/code-server/Machine/settings.json <<'CODE_SERVER_SETTINGS'
+{
+  "terminal.integrated.defaultProfile.linux": "fish",
+  "terminal.integrated.profiles.linux": {
+    "fish": {
+      "path": "/usr/bin/fish"
+    }
+  },
+  "terminal.integrated.fontFamily": "'JetBrainsMono Nerd Font', monospace",
+  "terminal.integrated.fontSize": 11,
+  "workbench.colorCustomizations": {
+    "terminal.background": "#1a1b26",
+    "terminal.foreground": "#a9b1d6",
+    "terminal.selectionBackground": "#28344a",
+    "terminalCursor.foreground": "#c0caf5",
+    "terminal.ansiBlack": "#15161e",
+    "terminal.ansiBrightBlack": "#414868",
+    "terminal.ansiRed": "#f7768e",
+    "terminal.ansiBrightRed": "#f7768e",
+    "terminal.ansiGreen": "#9ece6a",
+    "terminal.ansiBrightGreen": "#9ece6a",
+    "terminal.ansiYellow": "#e0af68",
+    "terminal.ansiBrightYellow": "#e0af68",
+    "terminal.ansiBlue": "#7aa2f7",
+    "terminal.ansiBrightBlue": "#7aa2f7",
+    "terminal.ansiMagenta": "#bb9af7",
+    "terminal.ansiBrightMagenta": "#bb9af7",
+    "terminal.ansiCyan": "#7dcfff",
+    "terminal.ansiBrightCyan": "#7dcfff",
+    "terminal.ansiWhite": "#a9b1d6",
+    "terminal.ansiBrightWhite": "#c0caf5"
+  }
+}
+CODE_SERVER_SETTINGS
+
+for command_name in fish eza bat zoxide btop; do
+    command -v "$command_name" >/dev/null 2>&1 || {
+        echo "Missing required dev terminal command: $command_name" >&2
+        exit 1
+    }
+done
+
+python3 -m json.tool /root/.local/share/code-server/Machine/settings.json >/dev/null
+
+# The integrated terminal uses Fish explicitly; administrative/root login paths
+# must remain on Bash (or another non-Fish shell).
+root_shell=$(getent passwd root | cut -d: -f7)
+case "$root_shell" in
+    */fish)
+        echo "Root login shell must not be Fish: $root_shell" >&2
+        exit 1
+        ;;
+esac
+
+systemctl is-active code-server@root >/dev/null 2>&1
+GUEST_SCRIPT
+
+    pct push "$ct_id" "$guest_script" "$remote_script"
+    pct exec "$ct_id" -- chmod 0700 "$remote_script"
+
+    if ! pct exec "$ct_id" -- "$remote_script"; then
+        pct exec "$ct_id" -- rm -f "$remote_script" || true
+        print_error "Failed to configure dev terminal"
+        return 1
+    fi
+
+    pct exec "$ct_id" -- rm -f "$remote_script"
+    print_success "Dev code-server terminal reconciled"
+}


### PR DESCRIPTION
## What changed

- add a dedicated `dev-terminal` deployment module for the Dev LXC
- install only server-side terminal tooling: Fish, eza, bat, zoxide, and btop
- mirror the useful NixOS Fish aliases (`ls`, `ll`, `la`, `tree`, `cat`)
- keep `/root`'s login shell unchanged; code-server explicitly launches Fish only for its integrated terminal
- add code-server machine-scoped terminal settings with JetBrainsMono Nerd Font, size 11, and the Tokyo Night palette from the NixOS Kitty config
- intentionally omit Kitty, Pure, Fisher, and terminal transparency from the Dev LXC
- run the same reconciliation from both full Dev deploys and fast Dev redeploys

## Why

The Dev LXC is accessed through code-server, so installing a GUI terminal emulator or a separate prompt theme would add unnecessary state. This keeps the server lean while retaining the useful shell workflow and visual palette from the NixOS desktop.

Machine-scoped code-server settings are used so the managed terminal configuration stays separate from personal user/editor settings. The code-server data directory is already persisted on fastpool, so these settings survive container recreation.

## Validation

- `bash -n` on `scripts/modules/dev-terminal.sh`
- `bash -n` on `scripts/deploy-stack.sh`
- `bash -n` on `scripts/fast-redeploy.sh`
- `bash -n` on the embedded guest provisioning script
- parsed the generated code-server `settings.json` with Python's JSON parser
- branch rewritten to a single commit based directly on `main`
- compared the branch against `main`: only the two orchestrator hooks and the new module are changed

The repository's existing PR validation workflow additionally runs ShellCheck and repository invariants.