### PR TITLE
Align Dev terminal and use Oh My Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Code-Server is reachable through the OTP-protected Nginx Proxy Manager route; pr
 
 - **Proxmox VE**: 9.x with ZFS storage
 - **Network**: `vmbr0` bridge, `192.168.1.x` range
-- **Storage**: ZFS pools — `fastpool` (SSD) for configs/databases) and `datapool` (HDD) for media/backups
+- **Storage**: ZFS pools — `fastpool` (SSD) for configs/databases and `datapool` (HDD) for media/backups
 - **GPU**: NVIDIA is required by the current Media and Desktop stack definitions; other stacks do not require it
 
 ## 🔐 Security

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This project utilizes custom Docker images that are maintained in separate repos
 | Image | Repository | Description |
 | :--- | :--- | :--- |
 | **desktop-workspace** | [Yakrel/docker-desktop-workspace](https://github.com/Yakrel/docker-desktop-workspace) | Multi-app web environment (Brave + Obsidian) |
-| **backrest-rclone** | [Yakrel/docker-backrest-rclone](https://github.com/Yakrel/docker-backrest-rclone) | Backup solution with Google Drive sync hooks |
+| **backrest-rclone** | [Yakrel/docker-backrest-rclone](https://github.com/Yakrel/docker-backrest-rclone) | Backup solution with Oracle VPS and Google Drive sync hooks |
 
 **Pipeline Features:**
 - Scheduled weekly rebuilds
@@ -169,7 +169,7 @@ Code-Server is reachable through the OTP-protected Nginx Proxy Manager route; pr
 
 - **Proxmox VE**: 9.x with ZFS storage
 - **Network**: `vmbr0` bridge, `192.168.1.x` range
-- **Storage**: ZFS pools — `fastpool` (SSD) for configs/databases, `datapool` (HDD) for media/backups
+- **Storage**: ZFS pools — `fastpool` (SSD) for configs/databases) and `datapool` (HDD) for media/backups
 - **GPU**: NVIDIA is required by the current Media and Desktop stack definitions; other stacks do not require it
 
 ## 🔐 Security

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This project utilizes custom Docker images that are maintained in separate repos
 | Image | Repository | Description |
 | :--- | :--- | :--- |
 | **desktop-workspace** | [Yakrel/docker-desktop-workspace](https://github.com/Yakrel/docker-desktop-workspace) | Multi-app web environment (Brave + Obsidian) |
-| **backrest-rclone** | [Yakrel/docker-backrest-rclone](https://github.com/Yakrel/docker-backrest-rclone) | Backup solution with Oracle VPS and Google Drive sync hooks |
+| **backrest-rclone** | [Yakrel/docker-backrest-rclone](https://github.com/Yakrel/docker-backrest-rclone) | Backup solution with Google Drive sync hooks |
 
 **Pipeline Features:**
 - Scheduled weekly rebuilds
@@ -112,9 +112,9 @@ Hermes Agent, OmniRoute
 The LXC firewall accepts the Hermes and OmniRoute application ports only from Nginx Proxy Manager. Outbound agent access remains allowed.
 
 ### **Development (Dev)** (LXC 105 - `192.168.1.105`)
-Code-Server, Node.js, Python, Git/GitHub CLI, Codex CLI, Antigravity CLI
+Code-Server, Node.js, Python, Git/GitHub CLI, Oh My Pi
 
-Code-Server is reachable through the OTP-protected Nginx Proxy Manager route; provisioning enables the Datacenter firewall while leaving node firewalling unchanged, and the LXC firewall permits direct port `8680` traffic only from NPM and the Homepage health monitor. Dev enables LXC nesting for Debian 13 systemd service isolation but leaves Docker-specific keyctl disabled. Code-Server settings and extensions persist under `/fastpool/config/code-server`, while `/root/workspace` persists under `/fastpool/config/dev/workspace`. CLI authentication state remains disposable with the Dev LXC.
+Code-Server is reachable through the OTP-protected Nginx Proxy Manager route; provisioning enables the Datacenter firewall while leaving node firewalling unchanged, and the LXC firewall permits direct port `8680` traffic only from NPM and the Homepage health monitor. Dev enables LXC nesting for Debian 13 systemd service isolation but leaves Docker-specific keyctl disabled. Code-Server settings and extensions persist under `/fastpool/config/code-server`, while `/root/workspace` persists under `/fastpool/config/dev/workspace`. Its integrated terminal mirrors the NixOS workstation shell with Zsh, Oh My Zsh (`git` + `robbyrussell`), autosuggestions, syntax highlighting, eza, bat, btop, zoxide, JetBrainsMono Nerd Font, and the same Tokyo Night palette. Oh My Pi is the only coding-agent CLI provisioned for Dev and provides the multi-provider agent surface; CLI authentication state remains disposable with the Dev LXC.
 
 ---
 
@@ -147,7 +147,8 @@ Code-Server is reachable through the OTP-protected Nginx Proxy Manager route; pr
 │   ├── setup-tailscale-host.sh # Tailscale host subnet configuration
 │   └── modules/             # Specialized deployment modules
 │       ├── docker-deployment.sh
-│       └── backrest-deployment.sh
+│       ├── backrest-deployment.sh
+│       └── dev-terminal.sh
 ├── docker/                   # Docker Compose stacks
 │   ├── ai/                  # Hermes Agent and OmniRoute
 │   ├── desktop/             # Dashboard, desktop workspace, guacamole, sshwifty, radicale

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Code-Server is reachable through the OTP-protected Nginx Proxy Manager route; pr
 
 - **Proxmox VE**: 9.x with ZFS storage
 - **Network**: `vmbr0` bridge, `192.168.1.x` range
-- **Storage**: ZFS pools — `fastpool` (SSD) for configs/databases and `datapool` (HDD) for media/backups
+- **Storage**: ZFS pools — `fastpool` (SSD) for configs/databases, `datapool` (HDD) for media/backups
 - **GPU**: NVIDIA is required by the current Media and Desktop stack definitions; other stacks do not require it
 
 ## 🔐 Security

--- a/scripts/lxc-manager.sh
+++ b/scripts/lxc-manager.sh
@@ -416,7 +416,7 @@ Components: main contrib non-free non-free-firmware
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 EOS
 
-    # Dev stack: code-server + AI CLI tools (no Docker, no GPU)
+    # Dev stack: code-server + developer CLI tools (no Docker, no GPU)
     if [ \"\$STACK_NAME\" = 'dev' ]; then
         nodesource_installer=\$(mktemp /tmp/nodesource-setup.XXXXXX)
         trap 'rm -f \"\$nodesource_installer\"' EXIT
@@ -647,27 +647,13 @@ fi
 systemctl enable code-server@root
 systemctl restart code-server@root
 
-# Install or update Codex with the official standalone installer. The installer
-# verifies the downloaded release against OpenAI-published SHA-256 metadata.
-codex_installer=$(mktemp /tmp/codex-install.XXXXXX)
-cleanup_codex_installer() { rm -f "$codex_installer"; }
-trap cleanup_codex_installer EXIT
-curl -fsSL https://chatgpt.com/codex/install.sh -o "$codex_installer"
-CODEX_NON_INTERACTIVE=1 bash "$codex_installer"
-rm -f "$codex_installer"
-trap - EXIT
-test "$(command -v codex)" = /root/.local/bin/codex
-codex --version
+# Oh My Pi is the single coding-agent CLI for Dev. It provides the multi-provider
+# agent surface without separately installing Codex, Claude Code, or Antigravity.
+curl -fsSL https://omp.sh/install | sh
+export PATH="/root/.local/bin:/usr/local/bin:$PATH"
+omp --version
 
-# Install Antigravity directly, without CLI wrappers.
-antigravity_installer=$(mktemp /tmp/antigravity-install.XXXXXX)
-curl -fsSL https://antigravity.google/cli/install.sh -o "$antigravity_installer"
-bash "$antigravity_installer" --dir /root/.local/lib/antigravity
-test -x /root/.local/lib/antigravity/agy
-ln -sfnT /root/.local/lib/antigravity/agy /usr/local/bin/agy
-rm -f "$antigravity_installer"
-
-for command_name in node npm git gh python3 bash nano vim htop shellcheck yq agy codex code-server; do
+for command_name in node npm git gh python3 bash nano vim htop shellcheck yq omp code-server; do
     command -v "$command_name" >/dev/null 2>&1 || {
         echo "Missing required dev command: $command_name" >&2
         exit 1
@@ -677,9 +663,7 @@ python3 -c "import yaml"
 
 systemctl is-enabled code-server@root >/dev/null 2>&1
 systemctl is-active code-server@root >/dev/null 2>&1
-test "$(command -v codex)" = /root/.local/bin/codex
-test "$(readlink -f "$(command -v agy)")" = /root/.local/lib/antigravity/agy
-! command -v opencode >/dev/null 2>&1
+command -v omp >/dev/null 2>&1
 '
     print_success "Dev CLI applications reconciled"
 fi

--- a/scripts/modules/dev-terminal.sh
+++ b/scripts/modules/dev-terminal.sh
@@ -49,10 +49,14 @@ source "$ZSH/oh-my-zsh.sh"
 eval "$(zoxide init zsh)"
 eval "$(omp completions zsh)"
 
-alias ls='eza --icons=auto'
-alias ll='eza -lh --icons=auto'
-alias la='eza -la --icons=auto'
-alias tree='eza --tree --icons=auto'
+# Match Home Manager's eza Zsh integration plus the explicit workstation aliases.
+alias eza='eza --icons=auto'
+alias ls='eza'
+alias ll='eza -lh'
+alias la='eza -la'
+alias lt='eza --tree'
+alias lla='eza -la'
+alias tree='eza --tree'
 alias cat='bat'
 
 source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh

--- a/scripts/modules/dev-terminal.sh
+++ b/scripts/modules/dev-terminal.sh
@@ -2,7 +2,7 @@
 
 # Dev LXC terminal experience shared by full deploys and fast redeploys.
 # Keeps the Proxmox/root login shell on Bash while making code-server's
-# integrated terminal use Zsh with Oh My Zsh and the desktop's Tokyo Night palette.
+# integrated terminal use Zsh with Oh My Zsh and the workstation's Tokyo Night palette.
 
 deploy_dev_terminal() {
     local ct_id="$1"
@@ -24,7 +24,7 @@ apt-get update -qq
 apt-get install -y -qq zsh git zsh-autosuggestions zsh-syntax-highlighting eza bat zoxide btop
 
 # Debian exposes the bat package as /usr/bin/batcat. Keep the familiar `bat`
-# command name available without adding runtime validation logic.
+# command name used by the NixOS shell configuration.
 ln -sfn /usr/bin/batcat /usr/local/bin/bat
 
 # Reconcile Oh My Zsh without its interactive installer so both fresh deploys
@@ -41,16 +41,19 @@ export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
 export ZSH="$HOME/.oh-my-zsh"
 
 ZSH_THEME="robbyrussell"
-plugins=(git zoxide)
+plugins=(git)
 zstyle ':omz:update' mode disabled
 
 source "$ZSH/oh-my-zsh.sh"
 
-alias ls='eza --icons'
-alias ll='eza -lh --icons'
-alias la='eza -la --icons'
-alias tree='eza --tree --icons'
-alias cat='batcat'
+eval "$(zoxide init zsh)"
+eval "$(omp completions zsh)"
+
+alias ls='eza --icons=auto'
+alias ll='eza -lh --icons=auto'
+alias la='eza -la --icons=auto'
+alias tree='eza --tree --icons=auto'
+alias cat='bat'
 
 source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh


### PR DESCRIPTION
## What changed

- Align the code-server integrated terminal with `Yakrel/nixos-config`: Zsh, Oh My Zsh with the `git` plugin and `robbyrussell` theme, autosuggestions, syntax highlighting, eza, bat, btop, zoxide, JetBrainsMono Nerd Font, and the matching Tokyo Night terminal palette.
- Remove direct Codex and Antigravity provisioning from the Dev LXC.
- Provision Oh My Pi as the single coding-agent CLI with `curl -fsSL https://omp.sh/install | sh`.
- Add OMP Zsh completions and update the Dev stack documentation.

## Why

Keep the code-server terminal consistent with the NixOS workstation while avoiding separate coding-agent installations. Oh My Pi provides the multi-provider agent surface from one CLI.

## Validation

- Compared the Dev terminal configuration against `modules/home/zsh.nix` and `modules/home/kitty.nix` in `Yakrel/nixos-config`.
- Verified the current Oh My Pi Linux installer defaults to `$HOME/.local/bin/omp` and supports `omp completions zsh`.
- Reviewed the branch diff against `main`; changes are limited to `README.md`, `scripts/lxc-manager.sh`, and `scripts/modules/dev-terminal.sh`.

## Existing Dev LXC note

This removes Codex/Antigravity from future provisioning and reconciliation. Existing binaries already left inside a currently deployed Dev LXC are intentionally not deleted by recurring automation; they can be removed once manually or disappear on a clean Dev LXC rebuild.