### PR TITLE
Harden Utility LAN access

### DIFF
--- a/docker/utility/docker-compose.yml
+++ b/docker/utility/docker-compose.yml
@@ -44,6 +44,9 @@ services:
     network_mode: host
     environment:
       - TZ=${TZ:-Europe/Istanbul}
+      # Restrict SMB to the fixed workstation and laptop addresses. The image
+      # maps this directly to Samba's global hosts allow setting.
+      - SAMBA_HOSTS_ALLOW=192.168.1.20 192.168.1.21
     volumes:
       - /fastpool/config/samba:/data
       # Share persistent data and service configuration without exposing the

--- a/docker/utility/docker-compose.yml
+++ b/docker/utility/docker-compose.yml
@@ -211,7 +211,6 @@ services:
     environment:
       - TZ=${TZ:-Europe/Istanbul}
       - PLAYWRIGHT_DRIVER_URL=ws://playwright-chrome:3000/?stealth=1&--disable-web-security=true
-      - ALLOW_IANA_RESTRICTED_ADDRESSES=true
     depends_on:
       - playwright-chrome
     networks:


### PR DESCRIPTION
## What changed

- Restrict the Utility stack's Samba server to `192.168.1.20` and `192.168.1.21` using the image-supported `SAMBA_HOSTS_ALLOW` setting.
- Remove `ALLOW_IANA_RESTRICTED_ADDRESSES=true` from ChangeDetection so it no longer explicitly opts into private/IANA-restricted target addresses.
- Leave the rest of the Utility services and ports unchanged.

## Why

Samba exposes writable access to `/datapool` and `/fastpool/config`, so it should only accept SMB sessions from the fixed workstation and laptop that actually use those shares.

ChangeDetection does not monitor any `byetgin.com` or other known private-LAN targets in this deployment, so the explicit private-address override is unnecessary and increases SSRF/lateral-access surface.

Keeping both changes at the application/container level avoids introducing a blanket Utility LXC firewall before cross-stack dependencies are fully mapped.

## Deployment impact

An existing Utility LXC does not need to be destroyed or recreated. Running the normal Utility deploy or `scripts/fast-redeploy.sh utility` refreshes `docker-compose.yml`; Docker Compose recreates the affected Samba and ChangeDetection services with the hardened settings.

## Dependency note

Runtime inspection confirmed Repackarr currently depends on Media LXC `192.168.1.101` at:

- qBittorrent: `8080`
- Prowlarr: `9696`

Those paths must remain allowed when the later LXC firewall rules are introduced.

## Validation

- Diff against `main`: one file only, 3 additions and 1 deletion.
- Previous PR validation passed before the ChangeDetection follow-up commit; the new commit will trigger validation again.
