### PR TITLE
Harden Media LXC ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Nginx Proxy Manager, AdGuard Home, Cloudflared
 ### **Media Automation** (LXC 101 - `192.168.1.101`)
 Jellyfin, Immich, Sonarr, Radarr, Bazarr, Seerr, Prowlarr, qBittorrent, FlareSolverr, Tor Proxy, Profilarr, Tdarr, Cleanuperr
 
-The Media LXC firewall drops inbound traffic by default. Nginx Proxy Manager and Homepage may reach the published web backends, while Repackarr is limited to qBittorrent and Prowlarr. qBittorrent peer traffic on TCP/UDP `6881` is the only unrestricted ingress; same-stack integrations use Docker service names on `media-net`.
+The Media LXC firewall drops inbound traffic by default. Nginx Proxy Manager and Homepage may reach the published web backends, while Repackarr is limited to qBittorrent and Prowlarr. qBittorrent peer traffic on TCP/UDP `6881` is the only unrestricted ingress; same-stack integrations use Docker service names on `media-net`. Immich PostgreSQL and Redis are isolated on the internal `immich-data-net`, shared only with `immich-server`.
 
 ### **Utility & Backup** (LXC 102 - `192.168.1.102`)
 JDownloader 2, Samba, Repackarr, Backrest-Rclone (encrypted repository with Oracle VPS and Google Drive mirrors), MeTube, Changedetection.io, Karakeep

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Nginx Proxy Manager, AdGuard Home, Cloudflared
 ### **Media Automation** (LXC 101 - `192.168.1.101`)
 Jellyfin, Immich, Sonarr, Radarr, Bazarr, Seerr, Prowlarr, qBittorrent, FlareSolverr, Tor Proxy, Profilarr, Tdarr, Cleanuperr
 
+The Media LXC firewall drops inbound traffic by default. Nginx Proxy Manager and Homepage may reach the published web backends, while Repackarr is limited to qBittorrent and Prowlarr. qBittorrent peer traffic on TCP/UDP `6881` is the only unrestricted ingress; same-stack integrations use Docker service names on `media-net`.
+
 ### **Utility & Backup** (LXC 102 - `192.168.1.102`)
 JDownloader 2, Samba, Repackarr, Backrest-Rclone (encrypted repository with Oracle VPS and Google Drive mirrors), MeTube, Changedetection.io, Karakeep
 

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -3,6 +3,9 @@ name: media
 networks:
   media-net:
     driver: bridge
+  immich-data-net:
+    driver: bridge
+    internal: true
 
 
 services:
@@ -318,6 +321,7 @@ services:
       disable: false
     networks:
       - media-net
+      - immich-data-net
     restart: unless-stopped
     stop_grace_period: 30s
     logging:
@@ -371,7 +375,7 @@ services:
     healthcheck:
       test: redis-cli ping || exit 1
     networks:
-      - media-net
+      - immich-data-net
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -396,7 +400,7 @@ services:
     healthcheck:
       disable: false
     networks:
-      - media-net
+      - immich-data-net
     shm_size: 128mb
     restart: unless-stopped
     stop_grace_period: 120s

--- a/docker/media/docker-compose.yml
+++ b/docker/media/docker-compose.yml
@@ -418,7 +418,6 @@ services:
       - media-net
     ports:
       - 8265:8265 # webUI
-      - 8266:8266 # server
     environment:
       - PUID=1000
       - PGID=1000

--- a/scripts/lxc-manager.sh
+++ b/scripts/lxc-manager.sh
@@ -22,7 +22,7 @@ reconcile_stack_firewall() {
     local firewall_tmp current_net desired_net
 
     case "$STACK_NAME" in
-        dev|desktop|ai) ;;
+        media|dev|desktop|ai) ;;
         *) return 0 ;;
     esac
 
@@ -38,6 +38,36 @@ policy_out: ACCEPT
 EOF
 
     case "$STACK_NAME" in
+        media)
+            cat >> "$firewall_tmp" <<'EOF'
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 2283
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 5055
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 6767
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 6868
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 7878
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 8080
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 8096
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 8265
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 8989
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 9696
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 11011
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 2283
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 5055
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 6767
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 6868
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 7878
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 8080
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 8096
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 8265
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 8989
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 9696
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 11011
+IN ACCEPT -source 192.168.1.102 -p tcp -dport 8080
+IN ACCEPT -source 192.168.1.102 -p tcp -dport 9696
+IN ACCEPT -p tcp -dport 6881
+IN ACCEPT -p udp -dport 6881
+EOF
+            ;;
         dev)
             cat >> "$firewall_tmp" <<'EOF'
 IN ACCEPT -source 192.168.1.100 -p tcp -dport 8680


### PR DESCRIPTION
## What changed

- Add the Media stack to the existing declarative Proxmox guest-firewall reconciliation.
- Set Media ingress to default `DROP` while keeping outbound traffic `ACCEPT`.
- Allow NPM (`192.168.1.100`) to reach the Media web backends it currently proxies.
- Allow Homepage (`192.168.1.103`) to reach the Media API/health ports it currently queries directly.
- Preserve Repackarr (`192.168.1.102`) access to qBittorrent `8080` and Prowlarr `9696`.
- Preserve qBittorrent peer ingress on TCP/UDP `6881` from any source.
- Stop publishing Tdarr server port `8266`; the configured internal node runs in the same container.
- Isolate Immich PostgreSQL and Redis on an internal `immich-data-net` shared only with `immich-server`.
- Document the Media ingress and internal Docker network policy in `README.md`.

## Why

The Media services are reverse-proxied through NPM, but their published LXC ports are currently reachable directly from other LAN clients. Restricting Media LXC ingress makes NPM the normal user entry path while preserving known cross-stack integrations and Homepage monitoring.

Same-stack application integrations use Docker DNS on `media-net` rather than NPM-backed public domains. Immich PostgreSQL and Redis do not need to be reachable by the other Media containers, so they use a separate internal network. `immich-server` remains on both networks; machine learning remains on `media-net` for server communication and outbound model access.

Verified live internal targets include:

- Sonarr/Radarr -> `qbittorrent:8080`
- Prowlarr -> `prowlarr:9696`, `sonarr:8989`, and `radarr:7878`
- Profilarr -> `sonarr:8989` and `radarr:7878`
- Bazarr -> `sonarr:8989` and `radarr:7878`
- Seerr -> `jellyfin:8096`, `sonarr:8989`, and `radarr:7878`
- Cleanuperr -> `sonarr:8989`, `radarr:7878`, and `qbittorrent:8080`

Repackarr is intentionally cross-LXC and was verified to use `192.168.1.101:8080` and `192.168.1.101:9696`.

## Allowed Media ingress

NPM and Homepage may reach TCP ports:

`2283, 5055, 6767, 6868, 7878, 8080, 8096, 8265, 8989, 9696, 11011`

Utility/Repackarr may reach TCP `8080` and `9696`.

qBittorrent peer traffic remains allowed on TCP/UDP `6881`. Everything else inbound to the Media LXC is denied.

## Deployment impact

No LXC recreation is required. Running Media Fast Redeploy reconciles `/etc/pve/firewall/101.fw`, enables firewalling on Media `net0`, removes Tdarr's unnecessary host publication for `8266`, creates `immich-data-net`, and recreates affected containers with their new network attachments. Persistent Immich data volumes are unchanged.

Clients that connect directly to `192.168.1.101:<service-port>` instead of using the NPM-backed domain will be blocked. NPM and Homepage retain their explicit source-based access; qBittorrent peer port `6881` is the unrestricted exception.

## Validation

- Compared every Media published port against NPM routes and Homepage direct widget/health targets.
- Inspected live application settings without changing them; same-stack integrations already use Docker service names.
- Verified live Repackarr backend addresses from its container environment.
- Parsed the Media Compose YAML and asserted the final network memberships.
- Checked `scripts/lxc-manager.sh` with `bash -n`.
- Proxmox VE documentation confirms the LXC `net[n]` `firewall` option controls whether interface firewall rules are applied.