### PR TITLE
Harden Utility LXC ingress and Docker networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The Media LXC firewall drops inbound traffic by default. Nginx Proxy Manager and
 ### **Utility & Backup** (LXC 102 - `192.168.1.102`)
 JDownloader 2, Samba, Repackarr, Backrest-Rclone (encrypted repository with Oracle VPS and Google Drive mirrors), MeTube, Changedetection.io, Karakeep
 
+The Utility LXC firewall drops inbound traffic by default. Nginx Proxy Manager and Homepage may reach the five published web backends, while SMB is limited to the fixed workstation and laptop addresses. Independent applications use separate Docker bridge networks; Changedetection shares a browser network with Playwright, while Karakeep bridges its browser network and an internal Meilisearch data network.
+
 ### **Desktop Workspace** (LXC 103 - `192.168.1.103`)
 Homepage, Desktop Workspace, Guacamole, Sshwifty, CouchDB, Vaultwarden, Desktop OTP Gate, Radicale CalDAV
 

--- a/docker/utility/docker-compose.yml
+++ b/docker/utility/docker-compose.yml
@@ -1,8 +1,23 @@
 name: utility
 
 networks:
-  utility-net:
+  jdownloader-net:
     driver: bridge
+  repackarr-net:
+    driver: bridge
+  backrest-net:
+    driver: bridge
+  metube-net:
+    driver: bridge
+  watchtower-net:
+    driver: bridge
+  changedetection-net:
+    driver: bridge
+  karakeep-browser-net:
+    driver: bridge
+  karakeep-data-net:
+    driver: bridge
+    internal: true
 
 volumes:
   samba-cache:
@@ -27,7 +42,7 @@ services:
       retries: 3
       start_period: 60s
     networks:
-      - utility-net
+      - jdownloader-net
     restart: unless-stopped
     stop_grace_period: 30s
     logging:
@@ -93,7 +108,7 @@ services:
       timeout: 10s
       retries: 3
     networks:
-      - utility-net
+      - repackarr-net
     logging:
       driver: "json-file"
       options:
@@ -134,7 +149,7 @@ services:
       retries: 3
       start_period: 40s
     networks:
-      - utility-net
+      - backrest-net
     logging:
       driver: "json-file"
       options:
@@ -163,7 +178,7 @@ services:
       retries: 3
       start_period: 40s
     networks:
-      - utility-net
+      - metube-net
     restart: unless-stopped
     logging:
       driver: "json-file"
@@ -190,7 +205,7 @@ services:
       - WATCHTOWER_NO_STARTUP_MESSAGE=true
       - WATCHTOWER_NOTIFICATION_TITLE_TAG=lxc-utility
     networks:
-      - utility-net
+      - watchtower-net
     logging:
       driver: "json-file"
       options:
@@ -214,7 +229,7 @@ services:
     depends_on:
       - playwright-chrome
     networks:
-      - utility-net
+      - changedetection-net
     logging:
       driver: "json-file"
       options:
@@ -240,7 +255,7 @@ services:
       - PREBOOT_CHROME=true
       - MAX_CONCURRENT_SESSIONS=10
     networks:
-      - utility-net
+      - changedetection-net
     logging:
       driver: "json-file"
       options:
@@ -273,7 +288,8 @@ services:
       - karakeep-meili
       - karakeep-chrome
     networks:
-      - utility-net
+      - karakeep-browser-net
+      - karakeep-data-net
     logging:
       driver: "json-file"
       options:
@@ -294,7 +310,7 @@ services:
       - --remote-debugging-port=9222
       - --hide-scrollbars
     networks:
-      - utility-net
+      - karakeep-browser-net
     logging:
       driver: "json-file"
       options:
@@ -314,7 +330,7 @@ services:
     volumes:
       - /fastpool/config/karakeep/meilisearch:/meili_data
     networks:
-      - utility-net
+      - karakeep-data-net
     logging:
       driver: "json-file"
       options:

--- a/scripts/lxc-manager.sh
+++ b/scripts/lxc-manager.sh
@@ -22,7 +22,7 @@ reconcile_stack_firewall() {
     local firewall_tmp current_net desired_net
 
     case "$STACK_NAME" in
-        media|dev|desktop|ai) ;;
+        media|utility|dev|desktop|ai) ;;
         *) return 0 ;;
     esac
 
@@ -66,6 +66,28 @@ IN ACCEPT -source 192.168.1.102 -p tcp -dport 8080
 IN ACCEPT -source 192.168.1.102 -p tcp -dport 9696
 IN ACCEPT -p tcp -dport 6881
 IN ACCEPT -p udp -dport 6881
+EOF
+            ;;
+        utility)
+            cat >> "$firewall_tmp" <<'EOF'
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 3080
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 5000
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 8081
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 8090
+IN ACCEPT -source 192.168.1.100 -p tcp -dport 9898
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 3080
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 5000
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 8081
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 8090
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 9898
+IN ACCEPT -source 192.168.1.20 -p udp -dport 137
+IN ACCEPT -source 192.168.1.20 -p udp -dport 138
+IN ACCEPT -source 192.168.1.20 -p tcp -dport 139
+IN ACCEPT -source 192.168.1.20 -p tcp -dport 445
+IN ACCEPT -source 192.168.1.21 -p udp -dport 137
+IN ACCEPT -source 192.168.1.21 -p udp -dport 138
+IN ACCEPT -source 192.168.1.21 -p tcp -dport 139
+IN ACCEPT -source 192.168.1.21 -p tcp -dport 445
 EOF
             ;;
         dev)


### PR DESCRIPTION
## What changed

- Add Utility LXC 102 to declarative Proxmox guest-firewall reconciliation.
- Set Utility inbound policy to `DROP` and outbound policy to `ACCEPT`.
- Allow NPM (`192.168.1.100`) and Homepage (`192.168.1.103`) to reach the five published Utility web backends on TCP `3080`, `5000`, `8081`, `8090`, and `9898`.
- Allow SMB only from the fixed workstation (`192.168.1.20`) and laptop (`192.168.1.21`) on UDP `137-138` and TCP `139/445`.
- Replace the shared `utility-net` with service- and dependency-specific bridge networks.
- Keep Karakeep browser traffic separate from its internal Meilisearch data network.
- Document the Utility ingress and Docker network policy in `README.md`.

## Network layout

- JDownloader, Repackarr, Backrest, MeTube, and Watchtower each receive an independent bridge network.
- Changedetection and Playwright share `changedetection-net`.
- Karakeep and Chrome share `karakeep-browser-net`.
- Karakeep and Meilisearch share internal `karakeep-data-net`; Meilisearch has no external route.
- Samba retains `network_mode: host` and its existing application-level allow-list for `192.168.1.20` and `192.168.1.21`.

## Why

Published Utility ports are currently directly reachable from other LAN clients, bypassing the NPM domain path and its configured authentication. The shared Docker network also gives unrelated applications direct container-network reachability to Backrest, browser automation, and Meilisearch. Source-restricted LXC ingress and dependency-specific Docker networks reduce both exposures without changing outbound integrations.

Repackarr's qBittorrent and Prowlarr connections are outbound and remain allowed. JDownloader, backup/offsite clients, browser automation, Karakeep inference, image pulls, and notification delivery also retain outbound access.

## Deployment impact

No LXC recreation is required. Utility Fast Redeploy writes `/etc/pve/firewall/102.fw`, enables firewalling on Utility `net0`, creates the new Docker networks, and recreates affected containers with unchanged persistent volumes.

Direct LAN access to Utility web ports will be blocked except from NPM and Homepage. SMB remains available only to the two configured client addresses.

## Validation

- Matched NPM proxy targets and Homepage widget/health targets against all five published Utility web ports.
- Confirmed live Repackarr dependencies are outbound to Media LXC.
- Parsed the Utility Compose YAML and asserted every final network membership.
- Confirmed the legacy `utility-net` is no longer referenced.
- Checked `scripts/lxc-manager.sh` with `bash -n`.