### PR TITLE
Harden Gateway LXC ingress and Docker networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ This project utilizes custom Docker images that are maintained in separate repos
 ### **Proxy & DNS (Gateway)** (LXC 100 - `192.168.1.100`)
 Nginx Proxy Manager, AdGuard Home, Cloudflared
 
+The Gateway LXC firewall permits LAN DNS and HTTPS proxy traffic while restricting the NPM and AdGuard administration ports to the Proxmox/Tailscale subnet router, Homepage, and the two fixed administrator devices. NPM and Cloudflared share `proxy-net`; AdGuard and Watchtower use independent Docker bridge networks.
+
 ### **Media Automation** (LXC 101 - `192.168.1.101`)
 Jellyfin, Immich, Sonarr, Radarr, Bazarr, Seerr, Prowlarr, qBittorrent, FlareSolverr, Tor Proxy, Profilarr, Tdarr, Cleanuperr
 

--- a/docker/gateway/docker-compose.yml
+++ b/docker/gateway/docker-compose.yml
@@ -1,7 +1,11 @@
 name: gateway
 
 networks:
-  gateway-net:
+  proxy-net:
+    driver: bridge
+  adguard-net:
+    driver: bridge
+  watchtower-net:
     driver: bridge
 
 
@@ -20,7 +24,7 @@ services:
     environment:
       - TZ=${TZ:-Europe/Istanbul}
     networks:
-      - gateway-net
+      - proxy-net
     healthcheck:
       test: ["CMD", "/bin/check-health"]
       interval: 10s
@@ -50,7 +54,7 @@ services:
     environment:
       - TZ=${TZ:-Europe/Istanbul}
     networks:
-      - gateway-net
+      - adguard-net
     logging:
       driver: "json-file"
       options:
@@ -70,7 +74,7 @@ services:
     healthcheck:
       disable: true
     networks:
-      - gateway-net
+      - proxy-net
     logging:
       driver: "json-file"
       options:
@@ -96,7 +100,7 @@ services:
       - WATCHTOWER_NO_STARTUP_MESSAGE=true
       - WATCHTOWER_NOTIFICATION_TITLE_TAG=lxc-gateway
     networks:
-      - gateway-net
+      - watchtower-net
     logging:
       driver: "json-file"
       options:

--- a/scripts/lxc-manager.sh
+++ b/scripts/lxc-manager.sh
@@ -22,7 +22,7 @@ reconcile_stack_firewall() {
     local firewall_tmp current_net desired_net
 
     case "$STACK_NAME" in
-        media|utility|dev|desktop|ai) ;;
+        gateway|media|utility|dev|desktop|ai) ;;
         *) return 0 ;;
     esac
 
@@ -38,6 +38,22 @@ policy_out: ACCEPT
 EOF
 
     case "$STACK_NAME" in
+        gateway)
+            cat >> "$firewall_tmp" <<'EOF'
+IN ACCEPT -source 192.168.1.0/24 -p tcp -dport 53
+IN ACCEPT -source 192.168.1.0/24 -p udp -dport 53
+IN ACCEPT -source 192.168.1.0/24 -p tcp -dport 80
+IN ACCEPT -source 192.168.1.0/24 -p tcp -dport 443
+IN ACCEPT -source 192.168.1.10 -p tcp -dport 81
+IN ACCEPT -source 192.168.1.10 -p tcp -dport 3000
+IN ACCEPT -source 192.168.1.20 -p tcp -dport 81
+IN ACCEPT -source 192.168.1.20 -p tcp -dport 3000
+IN ACCEPT -source 192.168.1.21 -p tcp -dport 81
+IN ACCEPT -source 192.168.1.21 -p tcp -dport 3000
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 81
+IN ACCEPT -source 192.168.1.103 -p tcp -dport 3000
+EOF
+            ;;
         media)
             cat >> "$firewall_tmp" <<'EOF'
 IN ACCEPT -source 192.168.1.100 -p tcp -dport 2283


### PR DESCRIPTION
## What changed

- Add Gateway LXC 100 to declarative Proxmox guest-firewall reconciliation.
- Set Gateway inbound policy to `DROP` and outbound policy to `ACCEPT`.
- Allow LAN clients (`192.168.1.0/24`) to use DNS on TCP/UDP `53` and NPM proxy ingress on TCP `80/443`.
- Restrict NPM `81` and AdGuard `3000` administration ports to the Proxmox/Tailscale subnet router (`192.168.1.10`), Homepage (`192.168.1.103`), workstation (`192.168.1.20`), and laptop (`192.168.1.21`).
- Replace the shared `gateway-net` with separate proxy, AdGuard, and Watchtower bridge networks.
- Document the Gateway ingress and Docker network policy in `README.md`.

## Network layout

- NPM and Cloudflared share `proxy-net` because tunnel traffic terminates at NPM.
- AdGuard uses `adguard-net` independently while retaining host-published DNS and administration ports.
- Watchtower uses `watchtower-net`; its Docker socket remains mounted, but it shares no container network with the public edge services.

## Tailscale compatibility

The Proxmox host advertises `192.168.1.0/24` with `NoSNAT: false`. Subnet-routed Tailscale traffic is therefore SNATed through the trusted Proxmox LAN address `192.168.1.10`. LAN DNS and proxy access are covered by the subnet rules, and direct administration/recovery access to ports `81/3000` is explicitly allowed from `192.168.1.10`.

## Why

Gateway currently has no guest firewall file. NPM `80/81/443` and AdGuard TCP/UDP `53` plus UI `3000` are bound on all interfaces, while AdGuard also listens on `0.0.0.0` without a client allow-list. Restricting ingress preserves LAN DNS, split-DNS domain access, Cloudflare Tunnel, Homepage monitoring, and Tailscale administration while blocking direct management access from other routed clients.

Separating Docker networks removes unnecessary direct container-network reachability between AdGuard, Watchtower, and the public proxy/tunnel pair.

## Deployment impact

No LXC recreation is required. Gateway Fast Redeploy writes `/etc/pve/firewall/100.fw`, enables firewalling on Gateway `net0`, creates the new Docker networks, and recreates affected containers with unchanged persistent volumes.

DNS and NPM proxy traffic remain available across `192.168.1.0/24`. Direct access to NPM `81` and AdGuard `3000` remains available only from the four trusted source addresses.

## Validation

- Inspected live Tailscale subnet-router preferences, Gateway `net0`, existing firewall state, and Docker network memberships.
- Confirmed no pre-existing `/etc/pve/firewall/100.fw` file.
- Confirmed NPM and AdGuard management proxy targets use the Gateway host address.
- Parsed the Gateway Compose YAML and asserted every final network membership.
- Confirmed the legacy `gateway-net` is no longer referenced.
- Checked `scripts/lxc-manager.sh` with `bash -n`.