### PR TITLE
Enable Meilisearch database upgrades

### DIFF
--- a/docker/utility/docker-compose.yml
+++ b/docker/utility/docker-compose.yml
@@ -326,6 +326,9 @@ services:
     environment:
       - TZ=${TZ:-Europe/Istanbul}
       - MEILI_NO_ANALYTICS=true
+      # Watchtower follows the latest image, so allow supported Meilisearch
+      # database upgrades when a newer engine replaces the running version.
+      - MEILI_UPGRADE_DB=true
       - MEILI_MASTER_KEY=${KARAKEEP_MEILI_MASTER_KEY:?Karakeep Meili master key is required}
     volumes:
       - /fastpool/config/karakeep/meilisearch:/meili_data


### PR DESCRIPTION
## What changed

- Enable Meilisearch's supported database upgrade path with `MEILI_UPGRADE_DB=true`.
- Keep the intentional `latest` image and Watchtower update policy.

## Why

Utility Fast Redeploy pulled Meilisearch 1.53.0 while the persisted Karakeep index was created by 1.49.0. Meilisearch correctly refused to start and entered a restart loop because database versions are engine-specific. The current engine explicitly requests the `--upgrade-db` flag or equivalent environment variable.

Keeping the upgrade flag in Compose allows supported database migrations whenever the intentional latest-image policy replaces the engine. Unsupported old databases still fail explicitly rather than being silently discarded.

## Deployment

Before redeploying, stop `karakeep-meili` and take a cold copy of `/fastpool/config/karakeep/meilisearch`; Meilisearch documents that database upgrades are not atomic. Then update the PVE checkout and run Utility Fast Redeploy.

## Validation

- Reproduced from live container state: Meilisearch exits `1` because database version `1.49.0` is incompatible with engine `1.53.0`.
- Confirmed the container was not OOM-killed.
- Parsed the final Compose environment and confirmed `MEILI_UPGRADE_DB=true` is applied without exposing the master key.
- Based on Meilisearch's documented self-hosted `--upgrade-db` procedure.