### PR TITLE
Simplify homelab page for interviews

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,257 +3,119 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Berkay Yetgin'in Proxmox homelab mimarisi: LXC iş yükü ayrımı, güvenli erişim, otomasyon, ZFS ve yedekleme/kurtarma kararları.">
+    <meta name="description" content="Berkay Yetgin'in Proxmox tabanlı kişisel homelab yapısının kısa teknik özeti.">
     <meta name="robots" content="index, follow">
     <meta name="author" content="Berkay Yetgin">
-    <meta name="theme-color" content="#0b0d10">
     <link rel="canonical" href="https://infra.byetgin.com/">
-    <meta property="og:title" content="Proxmox Homelab | Infrastructure Case Study">
-    <meta property="og:description" content="An actively used Proxmox homelab focused on workload isolation, secure access, repeatable deployment, and recovery.">
+    <meta property="og:title" content="Proxmox Homelab | Berkay Yetgin">
+    <meta property="og:description" content="Proxmox, LXC, Docker, ZFS, Tailscale, Cloudflare Tunnel ve backup yapısının kısa özeti.">
     <meta property="og:url" content="https://infra.byetgin.com/">
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Berkay Yetgin — Infrastructure">
     <title>Proxmox Homelab | Berkay Yetgin</title>
     <style>
         :root {
             color-scheme: dark;
             --bg: #0b0d10;
             --surface: #11151a;
-            --surface-2: #0c1015;
-            --border: #28303a;
-            --border-strong: #3a4654;
-            --text: #f4f6f8;
-            --soft: #d3d9e0;
-            --muted: #98a4b1;
+            --surface-2: #0d1116;
+            --border: #29313b;
+            --text: #f3f5f7;
+            --muted: #9ba7b4;
+            --soft: #d1d7dd;
             --accent: #8bb9ff;
-            --accent-strong: #6fa5f2;
-            --green: #7ed6a4;
-            --orange: #e7b878;
-            --max: 1160px;
+            --max: 1080px;
         }
         * { box-sizing: border-box; }
         html { scroll-behavior: smooth; }
         body {
             margin: 0;
-            background: radial-gradient(circle at 80% -10%, rgba(111, 165, 242, .11), transparent 35rem), var(--bg);
+            background: var(--bg);
             color: var(--text);
             font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-            line-height: 1.65;
-            -webkit-font-smoothing: antialiased;
+            line-height: 1.6;
         }
         a { color: inherit; }
-        button { font: inherit; }
         .wrap { width: min(var(--max), calc(100% - 40px)); margin: 0 auto; }
         header {
             position: sticky;
             top: 0;
-            z-index: 20;
-            border-bottom: 1px solid rgba(40, 48, 58, .85);
-            background: rgba(11, 13, 16, .88);
-            backdrop-filter: blur(16px);
+            z-index: 10;
+            border-bottom: 1px solid var(--border);
+            background: rgba(11, 13, 16, .94);
+            backdrop-filter: blur(12px);
         }
-        nav { min-height: 68px; display: flex; align-items: center; justify-content: space-between; gap: 18px; }
-        .brand { display: flex; align-items: center; gap: 10px; text-decoration: none; font-weight: 760; letter-spacing: -.02em; }
-        .brand-mark {
-            width: 32px;
-            height: 32px;
-            display: grid;
-            place-items: center;
-            border: 1px solid var(--border-strong);
-            border-radius: 9px;
-            background: var(--surface);
-            color: var(--accent);
-            font-size: 12px;
-            letter-spacing: .04em;
-        }
-        .nav-links { display: flex; align-items: center; justify-content: flex-end; gap: 18px; flex-wrap: wrap; }
+        nav { min-height: 64px; display: flex; align-items: center; justify-content: space-between; gap: 18px; }
+        .brand { text-decoration: none; font-weight: 760; letter-spacing: -.02em; }
+        .nav-links { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
         .nav-link, .lang-btn { border: 0; background: transparent; color: var(--muted); text-decoration: none; cursor: pointer; font-size: 13px; }
         .nav-link:hover, .lang-btn:hover, .lang-btn.active { color: var(--text); }
-        .lang-switch { display: inline-flex; gap: 5px; padding-left: 14px; border-left: 1px solid var(--border); }
-        main { padding-bottom: 72px; }
-        .hero { min-height: 670px; display: grid; align-content: center; padding: 92px 0 72px; }
-        .eyebrow { margin-bottom: 17px; color: var(--accent); font-size: 12px; font-weight: 760; letter-spacing: .12em; text-transform: uppercase; }
-        h1 { max-width: 980px; margin: 0; font-size: clamp(3rem, 7.7vw, 6.5rem); line-height: .98; letter-spacing: -.06em; }
-        .lead { max-width: 790px; margin: 28px 0 0; color: var(--soft); font-size: clamp(1.05rem, 2vw, 1.24rem); }
-        .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 30px; }
+        .lang-switch { display: inline-flex; gap: 5px; padding-left: 12px; border-left: 1px solid var(--border); }
+        main { padding-bottom: 64px; }
+        .hero { padding: 96px 0 72px; border: 0; }
+        .eyebrow { margin-bottom: 14px; color: var(--accent); font-size: 12px; font-weight: 760; letter-spacing: .11em; text-transform: uppercase; }
+        h1 { max-width: 840px; margin: 0; font-size: clamp(3rem, 8vw, 6rem); line-height: 1; letter-spacing: -.055em; }
+        .lead { max-width: 780px; margin-top: 24px; color: var(--soft); font-size: 1.08rem; }
+        .actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 28px; }
         .button {
-            min-height: 44px;
+            min-height: 42px;
             display: inline-flex;
             align-items: center;
-            justify-content: center;
-            padding: 0 16px;
+            padding: 0 15px;
             border: 1px solid var(--border);
-            border-radius: 9px;
+            border-radius: 8px;
             background: var(--surface);
-            color: var(--text);
             text-decoration: none;
             font-size: 14px;
-            font-weight: 680;
         }
-        .button.primary { border-color: var(--accent-strong); background: var(--accent-strong); color: #07101e; }
         .button:hover { border-color: var(--accent); }
-        .facts {
-            margin-top: 46px;
-            display: grid;
-            grid-template-columns: repeat(4, minmax(0, 1fr));
-            border: 1px solid var(--border);
-            border-radius: 14px;
-            background: rgba(17, 21, 26, .78);
-            overflow: hidden;
-        }
-        .fact { min-height: 108px; padding: 21px; }
+        .facts { margin-top: 42px; display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; background: var(--surface); }
+        .fact { padding: 19px; }
         .fact + .fact { border-left: 1px solid var(--border); }
-        .fact strong { display: block; color: var(--text); font-size: 1.18rem; letter-spacing: -.025em; }
+        .fact strong { display: block; margin-bottom: 4px; font-size: 1.12rem; }
         .fact span { color: var(--muted); font-size: 13px; }
-        section { padding: 82px 0; border-top: 1px solid var(--border); scroll-margin-top: 68px; }
-        .section-head { max-width: 800px; margin-bottom: 34px; }
-        .section-index { display: block; margin-bottom: 9px; color: var(--accent); font-size: 12px; font-weight: 760; letter-spacing: .1em; text-transform: uppercase; }
-        h2 { margin: 0; font-size: clamp(2rem, 4vw, 3.35rem); line-height: 1.08; letter-spacing: -.045em; }
-        .section-intro { margin: 17px 0 0; color: var(--muted); font-size: 1rem; }
-        h3 { margin: 0; font-size: 1.05rem; letter-spacing: -.015em; }
-        p { margin: 0; }
-        .architecture {
-            padding: 26px;
-            border: 1px solid var(--border);
-            border-radius: 16px;
-            background: linear-gradient(150deg, rgba(17, 21, 26, .96), rgba(12, 16, 21, .92));
-        }
-        .layer + .layer { margin-top: 20px; }
-        .layer-label { margin-bottom: 10px; color: var(--muted); font-size: 11px; font-weight: 760; letter-spacing: .1em; text-transform: uppercase; }
-        .node-grid { display: grid; gap: 10px; }
-        .node-grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-        .node-grid.five { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-        .node {
-            min-height: 103px;
-            padding: 17px;
-            border: 1px solid var(--border);
-            border-radius: 11px;
-            background: var(--surface-2);
-        }
-        .node.gateway { border-color: rgba(139, 185, 255, .55); background: rgba(111, 165, 242, .07); }
-        .node strong { display: block; margin-bottom: 5px; font-size: 14px; }
-        .node span { display: block; color: var(--muted); font-size: 12px; line-height: 1.5; }
-        .flow-arrow { padding: 9px 0 3px; color: var(--border-strong); text-align: center; font-size: 20px; }
-        .foundation { display: grid; grid-template-columns: 1.1fr 1fr 1fr; gap: 10px; }
-        .card-grid { display: grid; gap: 13px; }
-        .card-grid.five { grid-template-columns: repeat(5, minmax(0, 1fr)); }
-        .card-grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-        .card-grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-        .card { padding: 22px; border: 1px solid var(--border); border-radius: 13px; background: var(--surface); }
-        .card-number {
-            display: inline-grid;
-            width: 28px;
-            height: 28px;
-            margin-bottom: 16px;
-            place-items: center;
-            border-radius: 8px;
-            background: rgba(139, 185, 255, .1);
-            color: var(--accent);
-            font: 700 12px/1 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-        }
-        .card p { margin-top: 9px; color: var(--muted); font-size: 13px; }
-        .card code, .path code { color: var(--soft); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: .92em; }
-        .path {
-            margin-top: 18px;
-            padding: 18px 20px;
-            border: 1px solid var(--border);
-            border-radius: 11px;
-            background: var(--surface-2);
-            color: var(--soft);
-            font-size: 13px;
-            overflow-x: auto;
-            white-space: nowrap;
-        }
-        .path b { color: var(--accent); }
-        .recovery {
-            display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
-            border: 1px solid var(--border);
-            border-radius: 14px;
-            background: var(--surface);
-            overflow: hidden;
-        }
-        .recovery-step { min-height: 205px; padding: 24px; }
-        .recovery-step + .recovery-step { border-left: 1px solid var(--border); }
-        .recovery-step .tag {
-            display: inline-flex;
-            margin-bottom: 17px;
-            padding: 4px 8px;
-            border-radius: 6px;
-            background: rgba(126, 214, 164, .1);
-            color: var(--green);
-            font-size: 11px;
-            font-weight: 740;
-            text-transform: uppercase;
-            letter-spacing: .06em;
-        }
-        .recovery-step p { margin-top: 9px; color: var(--muted); font-size: 13px; }
-        .case-link { display: inline-flex; margin-top: 16px; color: var(--accent); text-decoration: none; font-size: 12px; font-weight: 700; }
-        .case-link:hover { text-decoration: underline; }
-        .limits { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
-        .limit {
+        section { padding: 68px 0; border-top: 1px solid var(--border); scroll-margin-top: 64px; }
+        .section-head { max-width: 760px; margin-bottom: 28px; }
+        .section-index { display: block; margin-bottom: 8px; color: var(--accent); font-size: 12px; font-weight: 760; letter-spacing: .08em; text-transform: uppercase; }
+        h2 { margin: 0; font-size: clamp(2rem, 4vw, 3rem); line-height: 1.08; letter-spacing: -.04em; }
+        .section-intro { margin-top: 13px; color: var(--muted); }
+        .architecture, .grid, .notes { display: grid; gap: 12px; }
+        .architecture { grid-template-columns: repeat(4, minmax(0, 1fr)); align-items: stretch; }
+        .grid.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .grid.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+        .card {
             padding: 20px;
-            border: 1px solid rgba(231, 184, 120, .28);
-            border-radius: 12px;
-            background: rgba(231, 184, 120, .035);
-        }
-        .limit strong { display: block; color: var(--orange); font-size: 14px; }
-        .limit p { margin-top: 7px; color: var(--muted); font-size: 13px; }
-        .deep-dive { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
-        .deep-link {
-            min-height: 150px;
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-            padding: 22px;
             border: 1px solid var(--border);
-            border-radius: 13px;
+            border-radius: 11px;
             background: var(--surface);
-            text-decoration: none;
         }
-        .deep-link:hover { border-color: var(--accent); transform: translateY(-2px); }
-        .deep-link span { color: var(--muted); font-size: 13px; }
-        .deep-link b { color: var(--accent); font-size: 13px; }
-        footer { padding: 30px 0 42px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
+        .card h3 { margin: 0 0 7px; font-size: 1rem; }
+        .card p { margin: 0; color: var(--muted); font-size: 13px; }
+        .arrow { display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 20px; }
+        .path { margin-top: 14px; padding: 15px 17px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface-2); color: var(--soft); font-size: 13px; overflow-x: auto; }
+        .notes { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+        .note { padding: 18px; border: 1px solid var(--border); border-radius: 10px; background: var(--surface-2); }
+        .note strong { display: block; margin-bottom: 6px; font-size: 14px; }
+        .note p { margin: 0; color: var(--muted); font-size: 13px; }
+        footer { padding: 28px 0 38px; border-top: 1px solid var(--border); color: var(--muted); font-size: 13px; }
         .footer-row { display: flex; justify-content: space-between; gap: 18px; flex-wrap: wrap; }
-        .footer-links { display: flex; gap: 15px; flex-wrap: wrap; }
+        .footer-links { display: flex; gap: 14px; flex-wrap: wrap; }
         .footer-links a { text-decoration: none; }
         .footer-links a:hover { color: var(--text); }
         body.lang-tr .en, body.lang-en .tr { display: none !important; }
-        @media (max-width: 980px) {
-            .nav-links .section-nav { display: none; }
+        @media (max-width: 860px) {
             .facts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
             .fact:nth-child(3) { border-left: 0; border-top: 1px solid var(--border); }
             .fact:nth-child(4) { border-top: 1px solid var(--border); }
-            .node-grid.five, .card-grid.five { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-            .node-grid.five .node:last-child, .card-grid.five .card:last-child { grid-column: 1 / -1; }
-            .card-grid.three, .deep-dive { grid-template-columns: 1fr; }
+            .architecture, .grid.three, .notes { grid-template-columns: 1fr; }
+            .arrow { transform: rotate(90deg); min-height: 28px; }
         }
-        @media (max-width: 720px) {
+        @media (max-width: 620px) {
             .wrap { width: min(var(--max), calc(100% - 28px)); }
-            nav { align-items: flex-start; padding: 16px 0; }
-            .nav-links { gap: 10px; }
-            .hero { min-height: auto; padding: 78px 0 62px; }
-            h1 { font-size: clamp(2.65rem, 14vw, 4.4rem); }
-            section { padding: 62px 0; }
-            .node-grid.three, .node-grid.five, .foundation, .card-grid.two, .card-grid.five, .limits, .recovery { grid-template-columns: 1fr; }
-            .node-grid.five .node:last-child, .card-grid.five .card:last-child { grid-column: auto; }
-            .recovery-step + .recovery-step { border-left: 0; border-top: 1px solid var(--border); }
-            .path { white-space: normal; }
-        }
-        @media (max-width: 520px) {
-            nav { display: block; }
-            .nav-links { margin-top: 11px; justify-content: flex-start; }
-            .facts { grid-template-columns: 1fr; }
+            nav { align-items: flex-start; padding: 15px 0; }
+            .nav-links .section-nav { display: none; }
+            .hero { padding: 72px 0 56px; }
+            .facts, .grid.two { grid-template-columns: 1fr; }
             .fact + .fact { border-left: 0; border-top: 1px solid var(--border); }
-            .architecture { padding: 16px; }
-        }
-        @media print {
-            header { position: static; background: var(--bg); }
-            .nav-links, .actions { display: none; }
-            .hero { min-height: auto; padding: 48px 0; }
-            section { break-inside: avoid; padding: 40px 0; }
-            .deep-dive { display: none; }
         }
     </style>
 </head>
@@ -261,18 +123,15 @@
     <header>
         <div class="wrap">
             <nav>
-                <a class="brand" href="#top" aria-label="Berkay Yetgin Infrastructure">
-                    <span class="brand-mark">BY</span>
-                    <span>Berkay Yetgin <span style="color:var(--muted);font-weight:520">/ Infrastructure</span></span>
-                </a>
+                <a class="brand" href="#top">Berkay Yetgin / Homelab</a>
                 <div class="nav-links">
                     <a class="nav-link section-nav tr" href="#architecture">Mimari</a>
                     <a class="nav-link section-nav en" href="#architecture">Architecture</a>
                     <a class="nav-link section-nav tr" href="#operations">Operasyon</a>
                     <a class="nav-link section-nav en" href="#operations">Operations</a>
-                    <a class="nav-link section-nav tr" href="#recovery">Kurtarma</a>
-                    <a class="nav-link section-nav en" href="#recovery">Recovery</a>
-                    <a class="nav-link" href="https://byetgin.com" target="_blank" rel="noopener"><span class="tr">Portfolyo</span><span class="en">Portfolio</span></a>
+                    <a class="nav-link section-nav tr" href="#backup">Yedek</a>
+                    <a class="nav-link section-nav en" href="#backup">Backup</a>
+                    <a class="nav-link" href="topology.html" target="_blank" rel="noopener"><span class="tr">Topoloji</span><span class="en">Topology</span></a>
                     <a class="nav-link" href="https://github.com/Yakrel/proxmox-homelab-automation" target="_blank" rel="noopener">GitHub</a>
                     <span class="lang-switch" aria-label="Language">
                         <button class="lang-btn" type="button" data-lang="tr">TR</button>
@@ -284,161 +143,116 @@
     </header>
 
     <main id="top" class="wrap">
-        <section class="hero" style="border-top:0">
-            <div class="eyebrow tr">Teknik vaka çalışması · Aktif homelab</div>
-            <div class="eyebrow en">Technical case study · Active homelab</div>
-            <h1 class="tr">Güvenli, tekrar kurulabilir ve kurtarılabilir bir Proxmox altyapısı.</h1>
-            <h1 class="en">A secure, repeatable, and recoverable Proxmox environment.</h1>
-            <p class="lead tr">Ailemin kullandığı servisleri barındıran bu kişisel ortamı altı ayrı LXC iş yükü alanında işletiyorum. Bu sayfa uygulama kataloğundan çok; ayrım, erişim, otomasyon ve arıza anında geri dönüş kararlarını gösterir.</p>
-            <p class="lead en">I operate this personal environment for services used by my family across six LXC workload domains. This page focuses on isolation, access, automation, and recovery decisions rather than presenting an application catalog.</p>
+        <section class="hero">
+            <div class="eyebrow tr">Kişisel homelab</div>
+            <div class="eyebrow en">Personal homelab</div>
+            <h1>Proxmox Homelab</h1>
+            <p class="lead tr">Evde kullandığım servisleri Proxmox üzerinde LXC'lere ayırarak çalıştırdığım kişisel ortam. Bu sayfada mimari, erişim, deployment ve backup yapısının kısa bir özeti var.</p>
+            <p class="lead en">My personal Proxmox environment for services I use at home. This page gives a short overview of its architecture, access paths, deployment flow, and backups.</p>
             <div class="actions">
-                <a class="button primary tr" href="#architecture">Mimariyi incele</a>
-                <a class="button primary en" href="#architecture">Explore the architecture</a>
+                <a class="button tr" href="#architecture">Mimari</a>
+                <a class="button en" href="#architecture">Architecture</a>
                 <a class="button tr" href="topology.html" target="_blank" rel="noopener">Etkileşimli topoloji</a>
                 <a class="button en" href="topology.html" target="_blank" rel="noopener">Interactive topology</a>
-                <a class="button tr" href="https://github.com/Yakrel/proxmox-homelab-automation" target="_blank" rel="noopener">Kaynak kod</a>
-                <a class="button en" href="https://github.com/Yakrel/proxmox-homelab-automation" target="_blank" rel="noopener">Source code</a>
+                <a class="button" href="https://github.com/Yakrel/proxmox-homelab-automation" target="_blank" rel="noopener">GitHub</a>
             </div>
-            <div class="facts" aria-label="Architecture facts">
-                <div class="fact"><strong>6 LXC</strong><span class="tr">Ayrılmış iş yükü alanı</span><span class="en">Separated workload domains</span></div>
-                <div class="fact"><strong>0 WAN</strong><span class="tr">Yönlendiricide açık gelen port</span><span class="en">Inbound router port forwards</span></div>
-                <div class="fact"><strong>ZFS + Restic</strong><span class="tr">Yerel geri dönüş ve şifreli yedek</span><span class="en">Local rollback and encrypted backup</span></div>
-                <div class="fact"><strong>Git-managed</strong><span class="tr">Konfigürasyon odaklı dağıtım</span><span class="en">Configuration-driven deployment</span></div>
+            <div class="facts">
+                <div class="fact"><strong>6 LXC</strong><span class="tr">İş yüklerini ayırmak için</span><span class="en">Separated workloads</span></div>
+                <div class="fact"><strong>Docker</strong><span class="tr">Uygulama servisleri</span><span class="en">Application services</span></div>
+                <div class="fact"><strong>ZFS</strong><span class="tr">Depolama ve snapshot</span><span class="en">Storage and snapshots</span></div>
+                <div class="fact"><strong>0 WAN port</strong><span class="tr">Router'da açık inbound port yok</span><span class="en">No inbound router port forwarding</span></div>
             </div>
         </section>
 
         <section id="architecture">
             <div class="section-head">
-                <span class="section-index tr">01 — Bir bakışta sistem</span>
-                <span class="section-index en">01 — System at a glance</span>
-                <h2 class="tr">Erişim yolu ile iş yükü aynı güven sınırında değil.</h2>
-                <h2 class="en">Access paths and workloads do not share one trust boundary.</h2>
-                <p class="section-intro tr">İnternet, özel yönetim erişimi ve yerel ağ farklı yollardan gelir; Gateway LXC istekleri DNS, reverse proxy ve tünel katmanında karşılar. Uygulama alanlarına yalnızca tanımlı akışlar geçer.</p>
-                <p class="section-intro en">Internet, private administration, and LAN traffic use different paths. The Gateway LXC terminates DNS, reverse proxy, and tunnel flows; only defined traffic proceeds to workload domains.</p>
+                <span class="section-index tr">01 — Mimari</span><span class="section-index en">01 — Architecture</span>
+                <h2 class="tr">Erişim, gateway ve iş yükleri ayrı katmanlarda.</h2>
+                <h2 class="en">Access, gateway, and workloads are separated.</h2>
+                <p class="section-intro tr">Yerel ağ, Tailscale ve Cloudflare Tunnel üzerinden gelen trafik önce gateway katmanına gelir. Uygulamalar ayrı LXC'lerde çalışır.</p>
+                <p class="section-intro en">LAN, Tailscale, and Cloudflare Tunnel traffic reaches the gateway layer first. Applications run in separate LXCs.</p>
             </div>
             <div class="architecture">
-                <div class="layer">
-                    <div class="layer-label tr">Erişim yolları</div><div class="layer-label en">Access paths</div>
-                    <div class="node-grid three">
-                        <div class="node"><strong class="tr">Yerel ağ + Split DNS</strong><strong class="en">LAN + split DNS</strong><span class="tr">Aynı alan adları, yerelde doğrudan NPM'e çözülür.</span><span class="en">The same domains resolve directly to NPM on the LAN.</span></div>
-                        <div class="node"><strong>Tailscale</strong><span class="tr">Proxmox ve özel ağ için şifreli yönetim yolu.</span><span class="en">Encrypted administration path to Proxmox and the private subnet.</span></div>
-                        <div class="node"><strong>Cloudflare Tunnel + Access</strong><span class="tr">Web yayınları için portsuz dış erişim.</span><span class="en">Port-forward-free web ingress for published services.</span></div>
-                    </div>
-                </div>
-                <div class="flow-arrow" aria-hidden="true">↓</div>
-                <div class="layer">
-                    <div class="layer-label tr">Giriş ve yönlendirme sınırı · LXC 100</div><div class="layer-label en">Ingress and routing boundary · LXC 100</div>
-                    <div class="node gateway"><strong>Gateway — DNS · Reverse Proxy · Tunnel</strong><span class="tr">AdGuard Home, Nginx Proxy Manager ve Cloudflared. Yönetim portları yalnızca açıkça izin verilen cihazlardan erişilebilir.</span><span class="en">AdGuard Home, Nginx Proxy Manager, and Cloudflared. Administrative ports are reachable only from explicitly allowed devices.</span></div>
-                </div>
-                <div class="flow-arrow" aria-hidden="true">↓</div>
-                <div class="layer">
-                    <div class="layer-label tr">İş yükü alanları · LXC 101–105</div><div class="layer-label en">Workload domains · LXC 101–105</div>
-                    <div class="node-grid five">
-                        <div class="node"><strong class="tr">Medya ve fotoğraf</strong><strong class="en">Media & photos</strong><span class="tr">GPU hızlandırmalı medya ve fotoğraf iş yükleri.</span><span class="en">GPU-accelerated media and photo workloads.</span></div>
-                        <div class="node"><strong class="tr">Araçlar ve yedek</strong><strong class="en">Utility & backup</strong><span class="tr">Dosya paylaşımı, yardımcı servisler ve yedek orkestrasyonu.</span><span class="en">File sharing, utility services, and backup orchestration.</span></div>
-                        <div class="node"><strong class="tr">Uzak çalışma alanı</strong><strong class="en">Remote workspace</strong><span class="tr">Tarayıcı tabanlı masaüstü ve kişisel üretkenlik servisleri.</span><span class="en">Browser-based desktop and personal productivity services.</span></div>
-                        <div class="node"><strong class="tr">AI ve otomasyon</strong><strong class="en">AI & automation</strong><span class="tr">Ajan arayüzü ve API yönlendirme katmanı.</span><span class="en">Agent interface and API routing layer.</span></div>
-                        <div class="node"><strong class="tr">Geliştirme</strong><strong class="en">Development</strong><span class="tr">Web IDE, çalışma ortamları ve CLI araçları.</span><span class="en">Web IDE, runtimes, and CLI tooling.</span></div>
-                    </div>
-                </div>
-                <div class="flow-arrow" aria-hidden="true">↓</div>
-                <div class="layer">
-                    <div class="layer-label tr">Fiziksel ve depolama temeli</div><div class="layer-label en">Compute and storage foundation</div>
-                    <div class="foundation">
-                        <div class="node"><strong>Proxmox VE 9</strong><span class="tr">Unprivileged LXC ve konsol odaklı yönetim.</span><span class="en">Unprivileged LXC and console-first administration.</span></div>
-                        <div class="node"><strong>ZFS fastpool / datapool</strong><span class="tr">Konfigürasyon-veritabanı ile büyük verinin ayrılması.</span><span class="en">Separation of configuration/databases from bulk data.</span></div>
-                        <div class="node"><strong>NVIDIA GPU</strong><span class="tr">Seçili LXC'lere paylaşılan hızlandırma.</span><span class="en">Shared acceleration for selected LXCs.</span></div>
-                    </div>
-                </div>
+                <div class="card"><h3 class="tr">Erişim</h3><h3 class="en">Access</h3><p>LAN / Split DNS<br>Tailscale<br>Cloudflare Tunnel + Access</p></div>
+                <div class="card"><h3>Gateway — LXC 100</h3><p>AdGuard Home<br>Nginx Proxy Manager<br>Cloudflared</p></div>
+                <div class="card"><h3 class="tr">İş yükleri — LXC 101–105</h3><h3 class="en">Workloads — LXC 101–105</h3><p class="tr">Medya, yardımcı servisler, uzak masaüstü, AI ve geliştirme ortamı</p><p class="en">Media, utility, remote desktop, AI, and development workloads</p></div>
+                <div class="card"><h3>Proxmox VE + ZFS</h3><p class="tr">LXC yönetimi, storage, snapshot ve seçili GPU paylaşımı</p><p class="en">LXC management, storage, snapshots, and selected GPU sharing</p></div>
             </div>
+            <div class="path">Internet → Cloudflare Tunnel → Nginx Proxy Manager → application LXC</div>
+            <div class="path">Admin device → Tailscale → private network → Proxmox / internal services</div>
         </section>
 
         <section id="operations">
             <div class="section-head">
-                <span class="section-index tr">02 — İşletim modeli</span><span class="section-index en">02 — Operating model</span>
-                <h2 class="tr">Sistem yalnızca kurulmadı; değişiklik ve geri dönüş yolları da tanımlandı.</h2>
-                <h2 class="en">The system was not only deployed; its change and recovery paths are defined.</h2>
+                <span class="section-index tr">02 — Operasyon</span><span class="section-index en">02 — Operations</span>
+                <h2 class="tr">Kurulum ve değişiklikleri mümkün olduğunca tekrar edilebilir tutuyorum.</h2>
+                <h2 class="en">I keep deployment and changes as repeatable as possible.</h2>
             </div>
-            <div class="card-grid five">
-                <article class="card"><span class="card-number">01</span><h3 class="tr">Tanımla</h3><h3 class="en">Define</h3><p class="tr">LXC kimlikleri ve kaynakları <code>stacks.yaml</code>; servis durumu Compose dosyaları ve şablonlarla tanımlanır.</p><p class="en">LXC identities and resources live in <code>stacks.yaml</code>; service state lives in Compose files and templates.</p></article>
-                <article class="card"><span class="card-number">02</span><h3 class="tr">Provision et</h3><h3 class="en">Provision</h3><p class="tr">İşletim sistemi katmanı temiz LXC kurulumu kabul eder. Yarım kalmış kurulum onarılmak yerine yeniden oluşturulur.</p><p class="en">The OS layer assumes clean LXC provisioning. Partial installations are recreated rather than patched in place.</p></article>
-                <article class="card"><span class="card-number">03</span><h3 class="tr">Yeniden dağıt</h3><h3 class="en">Redeploy</h3><p class="tr">Uygulama değişiklikleri aynı hazırlık yolunu kullanan stack veya toplu hızlı redeploy üzerinden uygulanır.</p><p class="en">Application changes use the same preparation path through per-stack or all-stack fast redeploy.</p></article>
-                <article class="card"><span class="card-number">04</span><h3 class="tr">Doğrula ve güncelle</h3><h3 class="en">Verify & update</h3><p class="tr">Docker healthcheck'leri, Homepage kontrolleri ve ayrık Watchtower zamanlamaları; güncelleme bildirimleri Telegram'a gider.</p><p class="en">Docker health checks, Homepage probes, and staggered Watchtower schedules feed update notifications to Telegram.</p></article>
-                <article class="card"><span class="card-number">05</span><h3 class="tr">Kurtar</h3><h3 class="en">Recover</h3><p class="tr">ZFS snapshot, şifreli restic repository ve yeniden kurulum akışı farklı arıza seviyeleri için ayrı yollar sağlar.</p><p class="en">ZFS snapshots, an encrypted restic repository, and the rebuild path cover different failure levels.</p></article>
+            <div class="grid two">
+                <div class="card"><h3 class="tr">Konfigürasyon</h3><h3 class="en">Configuration</h3><p class="tr"><code>stacks.yaml</code>, Docker Compose dosyaları ve servis şablonları repoda tutuluyor.</p><p class="en"><code>stacks.yaml</code>, Docker Compose files, and service templates are kept in the repository.</p></div>
+                <div class="card"><h3>Deployment</h3><p class="tr">Installer ve stack scriptleri ile LXC ve uygulama servislerini yeniden kurabiliyorum.</p><p class="en">Installer and stack scripts recreate LXCs and application services.</p></div>
+                <div class="card"><h3 class="tr">Güncelleme ve kontrol</h3><h3 class="en">Updates and checks</h3><p class="tr">Docker healthcheck, Homepage kontrolleri ve Watchtower ile temel servis durumunu ve container güncellemelerini takip ediyorum.</p><p class="en">Docker health checks, Homepage probes, and Watchtower cover basic service status and container updates.</p></div>
+                <div class="card"><h3 class="tr">Ağ kuralları</h3><h3 class="en">Network rules</h3><p class="tr">LXC'lerde inbound trafik varsayılan olarak kapalı; gerekli kaynak ve portlar ayrı ayrı izinli.</p><p class="en">Inbound LXC traffic is denied by default and required source/port pairs are allowed explicitly.</p></div>
             </div>
         </section>
 
         <section id="security">
             <div class="section-head">
-                <span class="section-index tr">03 — Güvenlik sınırları</span><span class="section-index en">03 — Security boundaries</span>
-                <h2 class="tr">Varsayılan yaklaşım açık erişim değil, gerekli akışa izin vermek.</h2>
-                <h2 class="en">The default is not broad access; it is permission for required flows.</h2>
+                <span class="section-index tr">03 — Erişim ve güvenlik</span><span class="section-index en">03 — Access and security</span>
+                <h2 class="tr">Yönetim trafiği ile yayınlanan web servislerini ayırıyorum.</h2>
+                <h2 class="en">Management traffic is separate from published web services.</h2>
             </div>
-            <div class="card-grid two">
-                <article class="card"><h3 class="tr">Ağ katmanı</h3><h3 class="en">Network layer</h3><p class="tr">Her LXC için gelen trafik varsayılan olarak düşürülür. NPM, yönetim cihazları ve zorunlu servis bağımlılıkları kaynak/port bazında açıkça izinlidir; stack içi veritabanları internal Docker ağlarında kalır.</p><p class="en">Inbound traffic is dropped by default per LXC. NPM, administration devices, and required service dependencies are explicitly allowed by source and port; stack-local databases remain on internal Docker networks.</p></article>
-                <article class="card"><h3 class="tr">Yönetim ve secret katmanı</h3><h3 class="en">Administration & secrets</h3><p class="tr">LXC'lerde SSH sunucusu yerine güvenilen Proxmox konsolu kullanılır. Hassas dosyalar Git'te salted AES-256-CBC ve PBKDF2-HMAC-SHA256 ile şifreli tutulur.</p><p class="en">Trusted Proxmox console access replaces SSH servers inside LXCs. Sensitive files remain encrypted in Git with salted AES-256-CBC and PBKDF2-HMAC-SHA256.</p></article>
-            </div>
-            <div class="path"><b class="tr">Web isteği:</b><b class="en">Web request:</b> Internet → Cloudflare Edge → Cloudflared → Nginx Proxy Manager → <code>explicitly allowed backend</code></div>
-            <div class="path"><b class="tr">Yönetim:</b><b class="en">Administration:</b> Admin device → Tailscale → Private subnet → <code>Proxmox / trusted management path</code></div>
-        </section>
-
-        <section id="recovery">
-            <div class="section-head">
-                <span class="section-index tr">04 — Yedekleme ve kurtarma</span><span class="section-index en">04 — Backup and recovery</span>
-                <h2 class="tr">Her kopya aynı problemi çözmüyor.</h2><h2 class="en">Each copy solves a different failure mode.</h2>
-                <p class="section-intro tr">Hızlı yerel geri dönüş, şifreli veri yedeği ve uzak repository erişilebilirliği birbirinden ayrıdır.</p>
-                <p class="section-intro en">Fast local rollback, encrypted data backup, and off-site repository availability are separate concerns.</p>
-            </div>
-            <div class="recovery">
-                <article class="recovery-step"><span class="tag tr">Yerel geri dönüş</span><span class="tag en">Local rollback</span><h3>ZFS + Sanoid</h3><p class="tr">Konfigürasyon hatası veya kazara silme için sık snapshot'lar. Host ayakta olduğu sürece en hızlı geri dönüş yoludur.</p><p class="en">Frequent snapshots for configuration mistakes or accidental deletion. This is the fastest path while the host remains available.</p></article>
-                <article class="recovery-step"><span class="tag tr">Şifreli yedek</span><span class="tag en">Encrypted backup</span><h3>Backrest + Restic</h3><p class="tr">Konfigürasyonlar ve seçili uygulama verileri istemci tarafında şifreli tek bir restic repository'ye yazılır; retention ve repository kontrolleri planlıdır.</p><p class="en">Configuration and selected application data are written to one client-side encrypted restic repository with scheduled retention and repository checks.</p></article>
-                <article class="recovery-step"><span class="tag tr">Uzak erişilebilirlik</span><span class="tag en">Off-site availability</span><h3>Oracle VPS + Google Drive</h3><p class="tr">Repository iki uzak hedefe aynalanır. Ayna hatası yerel backup'ı geçersiz kılmaz; Telegram uyarısı üretir.</p><p class="en">The repository is mirrored to two remote targets. Mirror failure does not invalidate the local snapshot; it raises a Telegram alert.</p></article>
+            <div class="grid three">
+                <div class="card"><h3>Tailscale</h3><p class="tr">Proxmox ve özel ağ erişimi için kullanıyorum.</p><p class="en">Used for Proxmox and private network access.</p></div>
+                <div class="card"><h3>Cloudflare Tunnel + Access</h3><p class="tr">Seçili web servislerine router portu açmadan erişim sağlıyor.</p><p class="en">Provides access to selected web services without router port forwarding.</p></div>
+                <div class="card"><h3 class="tr">Secret yönetimi</h3><h3 class="en">Secret handling</h3><p class="tr">Hassas konfigürasyon dosyaları Git'te şifreli tutuluyor; LXC yönetimini ağırlıklı olarak Proxmox konsolundan yapıyorum.</p><p class="en">Sensitive configuration files are encrypted in Git; LXC administration is mainly done through the Proxmox console.</p></div>
             </div>
         </section>
 
-        <section id="decisions">
+        <section id="backup">
             <div class="section-head">
-                <span class="section-index tr">05 — Teknik kararlar</span><span class="section-index en">05 — Technical decisions</span>
-                <h2 class="tr">Ağ erişimi, GPU paylaşımı ve yedekleme davranışı.</h2>
-                <h2 class="en">Network access, GPU sharing, and backup behavior.</h2>
+                <span class="section-index tr">04 — Yedekleme ve geri dönüş</span><span class="section-index en">04 — Backup and recovery</span>
+                <h2 class="tr">Snapshot, backup ve uzak kopyayı ayrı işler olarak kullanıyorum.</h2>
+                <h2 class="en">Snapshots, backups, and remote copies have separate roles.</h2>
             </div>
-            <div class="card-grid three">
-                <article class="card"><h3 class="tr">Gelen LXC trafiğinde default-deny</h3><h3 class="en">Default-deny inbound LXC traffic</h3><p class="tr">LXC düzeyinde <code>policy_in: DROP</code> ve <code>policy_out: ACCEPT</code> uygulanır; yalnızca gereken kaynak/port çiftleri açık izin kurallarıyla açılır. Reverse proxy, sağlık kontrolü ve zorunlu stack bağımlılıkları açıkça modellenir; SMB sabit yönetici cihazlarıyla sınırlandırılır.</p><p class="en">At the LXC layer, <code>policy_in: DROP</code> and <code>policy_out: ACCEPT</code> are enforced; only required source/port pairs are opened with explicit allow rules. Reverse proxy, health monitoring, and required cross-stack dependencies are modeled explicitly; SMB is limited to fixed administration devices.</p><a class="case-link" href="https://github.com/Yakrel/proxmox-homelab-automation/blob/main/scripts/lxc-manager.sh" target="_blank" rel="noopener"><span class="tr">Uygulamayı gör →</span><span class="en">View implementation →</span></a></article>
-                <article class="card"><h3 class="tr">Unprivileged LXC GPU paylaşımı</h3><h3 class="en">Unprivileged LXC GPU sharing</h3><p class="tr">cgroup v2 cihaz eşlemeleri ve host/container NVIDIA userspace sürüm uyumu ile medya iş yüklerine ayrıcalıklı konteyner kullanmadan hızlandırma verildi.</p><p class="en">cgroup v2 device mappings and host/container NVIDIA userspace alignment provide acceleration without privileged containers.</p><a class="case-link" href="https://github.com/Yakrel/proxmox-homelab-automation/blob/main/scripts/nvidia-userspace-sync.sh" target="_blank" rel="noopener"><span class="tr">Uygulamayı gör →</span><span class="en">View implementation →</span></a></article>
-                <article class="card"><h3 class="tr">Backup ile mirror ayrımı</h3><h3 class="en">Backup versus mirror semantics</h3><p class="tr">Uzak hedefler bağımsız retention arşivi gibi sunulmadı; aynı repository yaşam döngüsünü izleyen erişilebilirlik kopyaları olarak tasarlandı ve uyarı davranışı buna göre kuruldu.</p><p class="en">Remote targets are not presented as independent retention archives; they are availability copies following the same repository lifecycle, with alerts designed accordingly.</p><a class="case-link" href="https://github.com/Yakrel/proxmox-homelab-automation/blob/main/scripts/modules/backrest-deployment.sh" target="_blank" rel="noopener"><span class="tr">Uygulamayı gör →</span><span class="en">View implementation →</span></a></article>
+            <div class="grid three">
+                <div class="card"><h3>ZFS + Sanoid</h3><p class="tr">Yerel snapshot ve hızlı geri dönüş.</p><p class="en">Local snapshots and quick rollback.</p></div>
+                <div class="card"><h3>Backrest + Restic</h3><p class="tr">Seçili konfigürasyon ve uygulama verilerinin şifreli yedeği.</p><p class="en">Encrypted backup of selected configuration and application data.</p></div>
+                <div class="card"><h3>Oracle VPS + Google Drive</h3><p class="tr">Restic repository'nin iki uzak kopyası.</p><p class="en">Two remote copies of the Restic repository.</p></div>
             </div>
         </section>
 
-        <section id="limits">
+        <section id="notes">
             <div class="section-head">
-                <span class="section-index tr">06 — Bilinen sınırlar</span><span class="section-index en">06 — Known constraints</span>
-                <h2 class="tr">Bu bir kurumsal cluster değil; sınırları açıkça tanımlı kişisel altyapı.</h2>
-                <h2 class="en">This is not an enterprise cluster; it is a personal environment with explicit limits.</h2>
+                <span class="section-index tr">05 — Notlar</span><span class="section-index en">05 — Notes</span>
+                <h2 class="tr">Bu ortamın sınırları da net.</h2>
+                <h2 class="en">The limits of this environment are straightforward.</h2>
             </div>
-            <div class="limits">
-                <article class="limit"><strong class="tr">Tek fiziksel node, gerçek HA değil</strong><strong class="en">One physical node, not true HA</strong><p class="tr">Host arızası servis kesintisidir. Tasarım kesintisiz devretme yerine veri kurtarma ve yeniden kurulum süresini azaltmaya odaklanır.</p><p class="en">A host failure is a service outage. The design reduces recovery and rebuild time rather than providing failover.</p></article>
-                <article class="limit"><strong class="tr">Mirror, bağımsız retention değildir</strong><strong class="en">Mirrors are not independent retention</strong><p class="tr">Oracle ve Google Drive kopyaları yerel restic repository'nin forget/prune yaşam döngüsünü paylaşır.</p><p class="en">Oracle and Google Drive copies share the local restic repository's forget/prune lifecycle.</p></article>
-                <article class="limit"><strong class="tr">Ölçeğe uygun hafif izleme</strong><strong class="en">Right-sized lightweight monitoring</strong><p class="tr">Merkezi metrik/log stack'i daha önce işletildi; tek node homelab ölçeğinde kaynak ve bakım maliyeti ile unprivileged LXC entegrasyon yükü sağladığı değeri aşınca bilinçli olarak kaldırıldı. Güncel görünürlük Docker healthcheck'leri, Homepage kontrolleri ve hedefli bildirimlerle sağlanır.</p><p class="en">A centralized metrics/logging stack was operated previously, then deliberately removed when its resource and maintenance cost—and the integration overhead across unprivileged LXCs—outweighed its value at single-node homelab scale. Current visibility relies on Docker health checks, Homepage probes, and targeted notifications.</p></article>
-                <article class="limit"><strong class="tr">Genel ürün değil, ortama özel otomasyon</strong><strong class="en">Environment-specific automation, not a generic product</strong><p class="tr">Ağ, storage ve donanım varsayımları bilinçli olarak sabittir. Başka ortam için fork ve refactor gerekir.</p><p class="en">Network, storage, and hardware assumptions are intentionally fixed. Another environment requires a fork and refactor.</p></article>
+            <div class="notes">
+                <div class="note"><strong class="tr">Tek fiziksel node</strong><strong class="en">Single physical node</strong><p class="tr">Gerçek HA yok. Host arızasında servis kesintisi olur; amaç veriyi korumak ve yeniden kurulum süresini kısaltmak.</p><p class="en">There is no true HA. A host failure causes an outage; the goal is data protection and a shorter rebuild path.</p></div>
+                <div class="note"><strong class="tr">Ortama özel</strong><strong class="en">Environment specific</strong><p class="tr">Network, storage ve donanım değerleri kendi ev ortamıma göre tanımlı. Genel amaçlı ürün değil.</p><p class="en">Network, storage, and hardware values match my home environment. It is not a generic product.</p></div>
+                <div class="note"><strong class="tr">Basit izleme</strong><strong class="en">Simple monitoring</strong><p class="tr">Tek node ölçeğinde Docker healthcheck, Homepage ve bildirimleri yeterli tutuyorum.</p><p class="en">For a single-node homelab, I currently keep monitoring to Docker health checks, Homepage, and notifications.</p></div>
             </div>
         </section>
 
-        <section id="deep-dive">
+        <section id="links">
             <div class="section-head">
-                <span class="section-index tr">07 — İlgili kaynaklar</span><span class="section-index en">07 — Related resources</span>
-                <h2 class="tr">Kaynak kod ve etkileşimli topoloji.</h2><h2 class="en">Source code and interactive topology.</h2>
+                <span class="section-index tr">06 — Detaylar</span><span class="section-index en">06 — Details</span>
+                <h2 class="tr">İsterseniz mimariyi veya kaynak kodu daha detaylı inceleyebilirsiniz.</h2>
+                <h2 class="en">The topology and source code are available for a closer look.</h2>
             </div>
-            <div class="deep-dive">
-                <a class="deep-link" href="topology.html" target="_blank" rel="noopener"><div><h3 class="tr">Etkileşimli ağ topolojisi</h3><h3 class="en">Interactive network topology</h3><span class="tr">İstemci, erişim yolları, gateway ve LXC bağlantılarını ayrıntılı incele.</span><span class="en">Inspect clients, access paths, gateway, and LXC relationships.</span></div><b class="tr">Topolojiyi aç →</b><b class="en">Open topology →</b></a>
-                <a class="deep-link" href="https://github.com/Yakrel/proxmox-homelab-automation" target="_blank" rel="noopener"><div><h3 class="tr">Kaynak kod ve README</h3><h3 class="en">Source and README</h3><span class="tr">Deployment scriptleri, Compose tanımları, firewall ve backup uygulaması.</span><span class="en">Deployment scripts, Compose definitions, firewall, and backup implementation.</span></div><b>GitHub →</b></a>
-                <a class="deep-link" href="https://byetgin.com" target="_blank" rel="noopener"><div><h3 class="tr">Profesyonel profil</h3><h3 class="en">Professional profile</h3><span class="tr">Kurumsal Microsoft/endpoint deneyimi ve diğer seçilmiş çalışmalar.</span><span class="en">Enterprise Microsoft/endpoint experience and other selected work.</span></div><b class="tr">Portfolyoya dön →</b><b class="en">Return to portfolio →</b></a>
+            <div class="actions">
+                <a class="button tr" href="topology.html" target="_blank" rel="noopener">Etkileşimli topolojiyi aç</a>
+                <a class="button en" href="topology.html" target="_blank" rel="noopener">Open interactive topology</a>
+                <a class="button" href="https://github.com/Yakrel/proxmox-homelab-automation" target="_blank" rel="noopener">GitHub</a>
+                <a class="button" href="https://byetgin.com" target="_blank" rel="noopener">byetgin.com</a>
             </div>
         </section>
     </main>
 
     <footer>
         <div class="wrap footer-row">
-            <span>© 2026 Berkay Yetgin · Proxmox Homelab Case Study</span>
+            <span>© 2026 Berkay Yetgin · Proxmox Homelab</span>
             <div class="footer-links">
                 <a href="https://byetgin.com" target="_blank" rel="noopener">byetgin.com</a>
                 <a href="https://www.linkedin.com/in/berkayyetgin" target="_blank" rel="noopener">LinkedIn</a>


### PR DESCRIPTION
## Summary
- removes case-study / marketing-style wording from the homelab landing page
- shortens the page so the architecture can be explained quickly in an interview
- keeps the concrete technical details: Proxmox, LXC, Docker, ZFS, Tailscale, Cloudflare Tunnel, firewall rules and backups
- makes the single-node / non-HA limitation explicit
- keeps the interactive topology and GitHub links available for deeper questions

The goal is a more natural page that reads like a concise description of a real personal homelab rather than a portfolio sales page.